### PR TITLE
Ensure set_actor signal disconnection

### DIFF
--- a/src/auditlog/middleware.py
+++ b/src/auditlog/middleware.py
@@ -42,7 +42,7 @@ class AuditlogMiddleware(object):
         """
         pre_save.disconnect(sender=LogEntry, dispatch_uid=(self.__class__, request.auditlog_ts))
 
-        return response
+        return None
 
     @staticmethod
     def set_actor(user, sender, instance, **kwargs):


### PR DESCRIPTION
Mainly added sender kwarg to pre_save.disconnect, because the signal wasn't getting disconnected for me without it.

Timestamped the request and used that to connect/disconnect the signal, since the request could be modified by another middleware, which would prevent correct match on disconnect.

Added process_exception too.
