### PR TITLE
Integrate jsonfield_compat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django>=1.8
 django-jsonfield>=1.0.0
+django-jsonfield-compat==0.4.4

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     install_requires=[
         'Django>=1.8',
         'django-jsonfield>=1.0.0',
+        'django-jsonfield-compat==0.4.4',
     ],
     zip_safe=False
 )

--- a/src/auditlog/apps.py
+++ b/src/auditlog/apps.py
@@ -6,3 +6,8 @@ from django.apps import AppConfig
 class AuditlogConfig(AppConfig):
     name = 'auditlog'
     verbose_name = "Audit log"
+
+    def ready(self):
+        import jsonfield_compat
+
+        jsonfield_compat.register_app(self)

--- a/src/auditlog/migrations/0004_logentry_detailed_object_repr.py
+++ b/src/auditlog/migrations/0004_logentry_detailed_object_repr.py
@@ -2,7 +2,8 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import jsonfield.fields
+
+from jsonfield_compat import JSONField
 
 
 class Migration(migrations.Migration):
@@ -15,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='logentry',
             name='additional_data',
-            field=jsonfield.fields.JSONField(null=True, blank=True),
+            field=JSONField(null=True, blank=True),
         ),
     ]

--- a/src/auditlog/migrations/0005_logentry_additional_data_verbose_name.py
+++ b/src/auditlog/migrations/0005_logentry_additional_data_verbose_name.py
@@ -2,7 +2,8 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-import jsonfield.fields
+
+from jsonfield_compat import JSONField
 
 
 class Migration(migrations.Migration):
@@ -15,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='logentry',
             name='additional_data',
-            field=jsonfield.fields.JSONField(null=True, verbose_name='additional data', blank=True),
+            field=JSONField(null=True, verbose_name='additional data', blank=True),
         ),
     ]

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -11,7 +11,7 @@ from django.utils.encoding import python_2_unicode_compatible, smart_text
 from django.utils.six import iteritems, integer_types
 from django.utils.translation import ugettext_lazy as _
 
-from jsonfield.fields import JSONField
+from jsonfield_compat import JSONField
 
 
 class LogEntryManager(models.Manager):


### PR DESCRIPTION
This commit integrates django-jsonfield-compat which aims to fix #71 .

After using this branch, add
```
USE_NATIVE_JSONFIELD = True
```
to your project's settings, and then run `python manage.py migrate`.

This will update auditlog's LogEntry model to be a native JSONField type. You can switch everything back by changing the above setting to `False`, just be sure to run migrations afterwards.