### PR TITLE
Added support for tracking FK ID updates.

### DIFF
--- a/src/auditlog_tests/models.py
+++ b/src/auditlog_tests/models.py
@@ -66,7 +66,9 @@ class RelatedModel(models.Model):
     A model with a foreign key.
     """
 
-    related = models.ForeignKey(to='self', on_delete=models.CASCADE)
+    related = models.ForeignKey(
+        to='self', on_delete=models.CASCADE,
+        null=True, blank=True)
 
     history = AuditlogHistoryField()
 


### PR DESCRIPTION
In Django, you can update the raw ID of a ForeignKey relation
using the '*_id' field without assigning it a new model. This
needs to be logged by the audit framework. Currently it does
not detect these changes.