### PR TITLE
Add support for Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,7 @@ after_success:
 
 deploy:
   provider: pypi
-  user: jjkester
-  password:
-    secure: QjzH/Ef0aEFQ7tYmNY5eYsxLmAnC9dt3KPcvNhB0j+P4GvQVHJM1267yVkb6WEDyNBuYwuHUEifShSfHChpfzIDgAMzTOGTfEi5ub8SlzVZfj6e0w8GEmApxXldvtBHQBr4ekveoFU5QReR2F80s89JeYn0T2cq3JCrt1sPOCj0=
+  # PyPI credentials supplied with environment variables from repository settings
   on:
     repo: jjkester/django-auditlog
     branch: stable

--- a/src/auditlog/middleware.py
+++ b/src/auditlog/middleware.py
@@ -5,7 +5,10 @@ import time
 
 from django.conf import settings
 from django.db.models.signals import pre_save
-from django.utils.functional import curry
+try:
+    from functools import partialmethod
+except ImportError:
+    from django.utils.functional import curry as partialmethod
 from django.apps import apps
 from auditlog.models import LogEntry
 from auditlog.compat import is_authenticated
@@ -43,7 +46,7 @@ class AuditlogMiddleware(MiddlewareMixin):
 
         # Connect signal for automatic logging
         if hasattr(request, 'user') and is_authenticated(request.user):
-            set_actor = curry(self.set_actor, user=request.user, signal_duid=threadlocal.auditlog['signal_duid'])
+            set_actor = partialmethod(self.set_actor, user=request.user, signal_duid=threadlocal.auditlog['signal_duid'])
             pre_save.connect(set_actor, sender=LogEntry, dispatch_uid=threadlocal.auditlog['signal_duid'], weak=False)
 
     def process_response(self, request, response):

--- a/src/auditlog/middleware.py
+++ b/src/auditlog/middleware.py
@@ -6,7 +6,7 @@ import time
 from django.conf import settings
 from django.db.models.signals import pre_save
 try:
-    from functools import partialmethod
+    from functools import partial
 except ImportError:
     from django.utils.functional import curry as partialmethod
 from django.apps import apps

--- a/src/auditlog/middleware.py
+++ b/src/auditlog/middleware.py
@@ -46,7 +46,7 @@ class AuditlogMiddleware(MiddlewareMixin):
 
         # Connect signal for automatic logging
         if hasattr(request, 'user') and is_authenticated(request.user):
-            set_actor = partialmethod(self.set_actor, user=request.user, signal_duid=threadlocal.auditlog['signal_duid'])
+            set_actor = partial(self.set_actor, user=request.user, signal_duid=threadlocal.auditlog['signal_duid'])
             pre_save.connect(set_actor, sender=LogEntry, dispatch_uid=threadlocal.auditlog['signal_duid'], weak=False)
 
     def process_response(self, request, response):

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -10,8 +10,8 @@ from django.core.exceptions import FieldDoesNotExist
 from django.db import models, DEFAULT_DB_ALIAS
 from django.db.models import QuerySet, Q
 from django.utils import formats, timezone
-from django.utils.encoding import python_2_unicode_compatible, smart_text
-from django.utils.six import iteritems, integer_types
+from django.utils.encoding import smart_text
+from six import iteritems, integer_types, python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from jsonfield.fields import JSONField
@@ -259,7 +259,8 @@ class LogEntry(models.Model):
             values_display = []
             # handle choices fields and Postgres ArrayField to get human readable version
             choices_dict = None
-            if hasattr(field, 'choices') and len(field.choices) > 0:
+            choices_attr = getattr(field, 'choices', None)
+            if choices_attr is not None  and len(field.choices) > 0:
                 choices_dict = dict(field.choices)
             if hasattr(field, 'base_field') and getattr(field.base_field, 'choices', False):
                 choices_dict = dict(field.base_field.choices)

--- a/src/auditlog/registry.py
+++ b/src/auditlog/registry.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.db.models.signals import pre_save, post_save, post_delete
 from django.db.models import Model
-from django.utils.six import iteritems
+from six import iteritems
 
 
 class AuditlogModelRegistry(object):

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     {py34,py35,py36,py37}-django-20
     {py35,py36,py37}-django-21
     {py35,py36,py37}-django-22
+    {py36,py37}-django-30
 
 [testenv]
 setenv =
@@ -14,6 +15,7 @@ deps =
     django-20: Django>=2.0,<2.1
     django-21: Django>=2.1,<2.2
     django-22: Django>=2.2,<2.3
+    django-30: Django>=3.0,<3.1
     -r{toxinidir}/requirements-test.txt
 basepython =
     py37: python3.7


### PR DESCRIPTION
This primarily changes the use of deprecated imports, and adds
some logic for retaining support for python2.7 imports where needed.

Note that JSONField and multiselect, which are 3rd party modules,
do not yet support django 3 and both need updating for this to work:
JSONField needs the changes in imports, and multiselect needs a
method signature to be updated. I'll send pull requests to those
maintainers.