### PR TITLE
log create pass in kwargs to get_addtional_data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,7 @@ after_success:
 
 deploy:
   provider: pypi
-  user: jjkester
-  password:
-    secure: QjzH/Ef0aEFQ7tYmNY5eYsxLmAnC9dt3KPcvNhB0j+P4GvQVHJM1267yVkb6WEDyNBuYwuHUEifShSfHChpfzIDgAMzTOGTfEi5ub8SlzVZfj6e0w8GEmApxXldvtBHQBr4ekveoFU5QReR2F80s89JeYn0T2cq3JCrt1sPOCj0=
+  # PyPI credentials supplied with environment variables from repository settings
   on:
     repo: jjkester/django-auditlog
     branch: stable

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import json
 import ast
-import inspect
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
@@ -18,7 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from jsonfield.fields import JSONField
 from dateutil import parser
 from dateutil.tz import gettz
-
+from inspect import getargspec
 
 class LogEntryManager(models.Manager):
     """
@@ -49,7 +48,7 @@ class LogEntryManager(models.Manager):
 
             get_additional_data = getattr(instance, 'get_additional_data', None)
             if callable(get_additional_data):
-                if inspect.getfullargspec(get_additional_data).varkw:
+                if getargspec(get_additional_data).keywords:
                     kwargs.setdefault('additional_data', get_additional_data(**kwargs))
                 else:
                     kwargs.setdefault('additional_data', get_additional_data())

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import json
 import ast
+import inspect
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
@@ -48,7 +49,10 @@ class LogEntryManager(models.Manager):
 
             get_additional_data = getattr(instance, 'get_additional_data', None)
             if callable(get_additional_data):
-                kwargs.setdefault('additional_data', get_additional_data())
+                if inspect.getfullargspec(get_additional_data).varkw:
+                    kwargs.setdefault('additional_data', get_additional_data(**kwargs))
+                else:
+                    kwargs.setdefault('additional_data', get_additional_data())
 
             # Delete log entries with the same pk as a newly created model. This should only be necessary when an pk is
             # used twice.

--- a/src/auditlog_tests/models.py
+++ b/src/auditlog_tests/models.py
@@ -140,6 +140,29 @@ class AdditionalDataIncludedModel(models.Model):
         }
         return object_details
 
+class AdditionalDataIncludedWithKwargsModel(models.Model):
+    """
+    A model where get_additional_data is defined which allows for logging extra
+    information about the model in JSON
+    """
+
+    label = models.CharField(max_length=100)
+    text = models.TextField(blank=True)
+    related = models.ForeignKey(to=SimpleModel, on_delete=models.CASCADE)
+
+    history = AuditlogHistoryField()
+
+    def get_additional_data(self, **kwargs):
+        """
+        Returns JSON that captures a snapshot of additional details of the
+        model instance. This method, if defined, is accessed by auditlog
+        manager and added to each logentry instance on creation.
+        """
+        object_details = {
+            'action': kwargs.get('action')
+        }
+        return object_details
+
 
 class DateTimeFieldModel(models.Model):
     """
@@ -229,3 +252,4 @@ auditlog.register(ChoicesFieldModel)
 auditlog.register(CharfieldTextfieldModel)
 auditlog.register(PostgresArrayFieldModel)
 auditlog.register(NoDeleteHistoryModel)
+auditlog.register(AdditionalDataIncludedWithKwargsModel)

--- a/src/auditlog_tests/tests.py
+++ b/src/auditlog_tests/tests.py
@@ -271,7 +271,7 @@ class AdditionalDataModelTest(TestCase):
             label='Additional data to log entries', related=related_model)
         obj_with_additional_data.save()
         self.assertTrue(obj_with_additional_data.history.count() == 1,
-                        msg="There is 1 log entry")
+                        msg="There is 1 log  entry")
         log_entry = obj_with_additional_data.history.get()
         self.assertIsNotNone(log_entry.additional_data)
         extra_data = log_entry.additional_data

--- a/src/auditlog_tests/tests.py
+++ b/src/auditlog_tests/tests.py
@@ -270,9 +270,8 @@ class AdditionalDataModelTest(TestCase):
         obj_with_additional_data = AdditionalDataIncludedWithKwargsModel(
             label='Additional data to log entries', related=related_model)
         obj_with_additional_data.save()
-        msg = f"There is 1 log entry {obj_with_additional_data.history.all()}"
         self.assertTrue(obj_with_additional_data.history.count() == 1,
-                        msg=msg)
+                        msg="There is 1 log entry")
         log_entry = obj_with_additional_data.history.get()
         self.assertIsNotNone(log_entry.additional_data)
         extra_data = log_entry.additional_data


### PR DESCRIPTION
This is so that get_additional_data can generate a string for the timeline. I need to be able to get the actor and the changes from the kwargs. I am only passing in kwargs if get_additional_data has a **kwargs argument to ensure that this is backwards compatible with code that is already written