### PR TITLE
Add a DB index to `LogEntry`'s `action` field

### DIFF
--- a/auditlog/migrations/0008_action_index.py
+++ b/auditlog/migrations/0008_action_index.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("auditlog", "0007_object_pk_type"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="logentry",
+            name="action",
+            field=models.PositiveSmallIntegerField(
+                choices=[(0, "create"), (1, "update"), (2, "delete")],
+                db_index=True,
+                verbose_name="action",
+            ),
+        ),
+    ]

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -213,7 +213,7 @@ class LogEntry(models.Model):
     )
     object_repr = models.TextField(verbose_name=_("object representation"))
     action = models.PositiveSmallIntegerField(
-        choices=Action.choices, verbose_name=_("action")
+        choices=Action.choices, verbose_name=_("action"), db_index=True
     )
     changes = models.TextField(blank=True, verbose_name=_("change message"))
     actor = models.ForeignKey(


### PR DESCRIPTION
For some applications the possibility to filter by the `action` field might be really interesting. However the lack of an index can lead to severe reduction of such queries.

The simplest solution: Let's a DB index on that field :)