### PR TITLE
[TASK] Support newer versions of python-dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='Audit log app for Django',
     install_requires=[
         'django-jsonfield>=1.0.0',
-        'python-dateutil==2.6.0'
+        'python-dateutil>= 2.6.0, < 2.9'
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
python-dateutil only drops support for python 2.6 and 3.2 in python-dateutil version 2.7.0. This makes python-dateutil 2.7.0 and 2.8.0 still compatible with auditlog.

In one of mine envrionments python-dateutil 2.8.0 is installed and django-auditlog works with this, only pip will complain every time that versions are not compatible.