### PR TITLE
Adding optional OpenTracing integration.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django-jsonfield>=1.0.0
-python-dateutil==2.6.0
+opentracing==2.3.0
+python-dateutil==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-auditlog',
-    version='0.4.7',
+    version='0.4.7.1',
     packages=['auditlog', 'auditlog.migrations', 'auditlog.management', 'auditlog.management.commands'],
     package_dir={'': 'src'},
     url='https://github.com/jjkester/django-auditlog',
@@ -11,8 +11,11 @@ setup(
     description='Audit log app for Django',
     install_requires=[
         'django-jsonfield>=1.0.0',
-        'python-dateutil==2.6.0'
+        'python-dateutil==2.8.1'
     ],
+    extras_require={
+        "opentracing": ["opentracing>=2.3.0"]
+    },
     zip_safe=False,
     classifiers=[
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
[OpenTracing](https://opentracing.io/) provides the ability for
distributed tracing independent of vendor or downstream consumer.

This commit optionally adds an OpenTracing span in the receiver methods. The
spans are defined as `django-auditlog.{action}.{model_name}`, where
`action` is either `create`, `update`, or `delete`. This allows for
analysis on the performance impacted created through audit logging.

To install it, include the extra "opentracing"
Ex: `pip install django-auditlog[opentracing]`