### PR TITLE
Adding Custom Pre- and Post- Log Hooks

### DIFF
--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -113,7 +113,7 @@ def log_delete(sender, instance, **kwargs):
             post_log.send(
                 sender,
                 instance=instance,
-                action=LogAction.UPDATE,
+                action=LogAction.DELETE,
                 error=error,
                 pre_log_results=pre_log_results,
             )

--- a/auditlog/signals.py
+++ b/auditlog/signals.py
@@ -1,0 +1,66 @@
+from enum import Enum, unique
+
+import django.dispatch
+
+
+@unique
+class LogAction(Enum):
+    """
+    Enum representing actions that a receiver may want to handle differently.
+    """
+
+    CREATE = "create"
+    UPDATE = "update"
+    DELETE = "delete"
+
+
+pre_log = django.dispatch.Signal()
+"""
+Whenever an audit log entry is written, this signal
+is sent before writing the log.
+
+Parameters sent with this signal:
+
+:param class sender: 
+    The model class that's being audited
+    
+:param Any instance:
+    The actual instance that's being audited.
+
+:param LogAction action:
+    The action on the model resulting in an
+    audit log entry. Type: :class:`LogAction`
+    
+The receivers' return values are sent to any :func:`post_log`
+signal receivers.
+"""
+
+post_log = django.dispatch.Signal()
+"""
+Whenever an audit log entry is written, this signal
+is sent before writing the log.
+
+Keyword arguments sent with this signal:
+
+:param class sender:
+    The model class that's being audited.
+    
+:param Any instance:
+    The actual instance that's being audited.
+
+:param LogAction action:
+    The action on the model resulting in an
+    audit log entry. Type: :class:`LogAction`
+    
+:param Optional[Exception] error:
+    The error, if one occurred while saving the audit log entry. ``None``,
+    otherwise
+    
+:param List[Tuple[method,Any]] pre_log_results:
+    List of tuple pairs ``[(pre_log_receiver, pre_log_response)]``, where
+    ``pre_log_receiver`` is the receiver method, and ``pre_log_response`` is the
+    corresponding response of that method. If there are no :const:`pre_log` receivers,
+    then the list will be empty. ``pre_log_receiver`` is guaranteed to be
+    non-null, but ``pre_log_response`` may be ``None``. This depends on the corresponding
+    ``pre_log_receiver``'s return value.
+"""

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -642,3 +642,7 @@ class NoDeleteHistoryTest(TestCase):
             list(entries.values_list('action', flat=True)),
             [LogEntry.Action.CREATE, LogEntry.Action.UPDATE, LogEntry.Action.DELETE]
         )
+
+
+# class CustomSignalTest(TestCase):
+

--- a/docs/source/internals.rst
+++ b/docs/source/internals.rst
@@ -25,6 +25,22 @@ Signal receivers
 .. automodule:: auditlog.receivers
     :members:
 
+Custom Signals
+--------------
+Django Auditlog provides two custom signals that will hook in before
+and after any Auditlog record is written from a ``create``, ``update``,
+or ``delete`` action on an audited model.
+
+.. autoclass:: auditlog.signals.LogAction
+    :members:
+    :undoc-members:
+    :member-order: bysource
+
+.. automodule:: auditlog.signals
+    :members:
+    :exclude-members: LogAction
+    :member-order: bysource
+
 Calculating changes
 -------------------
 


### PR DESCRIPTION
As recommended, I've added two new custom hooks. One for before the audit log is written, and one for after. This enabled use cases around performance tracing, and hopefully others that I have not thought of.