### PR TITLE
Moving middleware user auth check to `set_actor()`

### DIFF
--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -155,7 +155,7 @@ class MiddlewareTest(TestCase):
 
         history = obj.history.get()
         self.assertEqual(history.remote_addr, test_remote_addr, msg="Remote address is {}".format(test_remote_addr))
-        self.assertIsNotNone(history.actor, msg="Actor is `None` for anonymous user")
+        self.assertIsNone(history.actor, msg="Actor is `None` for anonymous user")
 
         # Finalize transaction
         self.middleware.process_exception(request, None)


### PR DESCRIPTION
Move the check for whether the user is authenticated from before
registering `set_actor()` as the `pre_save` signal receiver
in to `set_actor()`. This enables two things:

1. `remote_addr` in the `LogEntry` is set even if the user is
   not authenticated.
2. This middleware no longer execute before the user is set
   on the request. Some frameworks may set this in a
   following middleware. Some frameworks, such as the widely
   adopeted Django Rest Framework do not set this as part
   of a middleware. So, the upshot of hit is that the
   actor will not be set when using Django Rest Framework.