### PR TITLE
Adding Foriegn Key Only Fields

### DIFF
--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -30,7 +30,8 @@ class AuditlogModelRegistry(object):
             self._signals.update(custom)
 
     def register(self, model: ModelBase = None, include_fields: Optional[List[str]] = None,
-                 exclude_fields: Optional[List[str]] = None, mapping_fields: Optional[Dict[str, str]] = None):
+                 exclude_fields: Optional[List[str]] = None, mapping_fields: Optional[Dict[str, str]] = None,
+                 fk_only_fields: Optional[List[str]] = None):
         """
         Register a model with auditlog. Auditlog will then track mutations on this model's instances.
 
@@ -38,7 +39,7 @@ class AuditlogModelRegistry(object):
         :param include_fields: The fields to include. Implicitly excludes all other fields.
         :param exclude_fields: The fields to exclude. Overrides the fields to include.
         :param mapping_fields: Mapping from field names to strings in diff.
-
+        :param fk_only_fields: Only record the FK value for these relational fields.
         """
 
         if include_fields is None:
@@ -47,6 +48,8 @@ class AuditlogModelRegistry(object):
             exclude_fields = []
         if mapping_fields is None:
             mapping_fields = {}
+        if fk_only_fields is None:
+            fk_only_fields = []
 
         def registrar(cls):
             """Register models for a given class."""
@@ -57,6 +60,7 @@ class AuditlogModelRegistry(object):
                 'include_fields': include_fields,
                 'exclude_fields': exclude_fields,
                 'mapping_fields': mapping_fields,
+                'fk_only_fields': fk_only_fields,
             }
             self._connect_signals(cls)
 
@@ -104,6 +108,7 @@ class AuditlogModelRegistry(object):
             'include_fields': list(self._registry[model]['include_fields']),
             'exclude_fields': list(self._registry[model]['exclude_fields']),
             'mapping_fields': dict(self._registry[model]['mapping_fields']),
+            'fk_only_fields': list(self._registry[model]['fk_only_fields']),
         }
 
     def _connect_signals(self, model):

--- a/auditlog_tests/models.py
+++ b/auditlog_tests/models.py
@@ -212,6 +212,11 @@ class NoDeleteHistoryModel(models.Model):
     history = AuditlogHistoryField(delete_related=False)
 
 
+class FKOnlyFieldTestModel(models.Model):
+    text = models.CharField(max_length=50)
+    related_model = models.ForeignKey(SimpleModel, on_delete=models.CASCADE)
+
+
 auditlog.register(AltPrimaryKeyModel)
 auditlog.register(UUIDPrimaryKeyModel)
 auditlog.register(ProxyModel)
@@ -226,3 +231,7 @@ auditlog.register(ChoicesFieldModel)
 auditlog.register(CharfieldTextfieldModel)
 auditlog.register(PostgresArrayFieldModel)
 auditlog.register(NoDeleteHistoryModel)
+auditlog.register(FKOnlyFieldTestModel,
+                  fk_only_fields=['related_model'],
+                  mapping_fields={'related_model': 'related_model_pk'},
+                  )

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -32,7 +32,8 @@ It is recommended to place the register code (``auditlog.register(MyModel)``) at
 This ensures that every time your model is imported it will also be registered to log changes. Auditlog makes sure that
 each model is only registered once, otherwise duplicate log entries would occur.
 
-**Excluding fields**
+Excluding fields
+````````````````
 
 Fields that are excluded will not trigger saving a new log entry and will not show up in the recorded changes.
 
@@ -50,7 +51,33 @@ For example, to exclude the field ``last_updated``, use::
 
     Excluding fields
 
-**Mapping fields**
+Foreign Key Only Fields
+```````````````````````
+
+If your models have many relations, performance may be slow if following all relations to build the changes
+between actions for logging. Primary key only fields will only have their primary key logged in changes,
+instead of the entire related model. To designate fields as primary key only fields, pass as list of strings
+as ``fk_only_fields`` to the ``register()`` call.
+
+.. code-block:: python
+
+    class MyModel(modelsModel):
+        sku = models.CharField(max_length=20)
+        version = models.CharField(max_length=5)
+        product = models.CharField(max_length=50, verbose_name='Product Name')
+        other_model = models.ForeignKey("MyOtherModel", related_name="+", on_delete=models.PROTECT)
+
+    auditlog.register(MyModel, fk_only_fields=["other_model"])
+
+There is no validation done on ``register()``. If the field is not included in the :class:`LogEntry`'s
+diff, including it in ``fk_only_fields`` has no effect.
+
+.. versionadded:: 1.0
+
+    Primary key only fields
+
+Mapping fields
+``````````````
 
 If you have field names on your models that aren't intuitive or user friendly you can include a dictionary of field mappings
 during the `register()` call.


### PR DESCRIPTION
When building the changes JSON for a LogEntry, following
relations (e.g. `ForeigKey` fields) can resutl in a
significant performance penalty. This commit adds support for
only logging to foreign key value, by specifying
fields to log in this manner wiht a `fk_only_fields`
when registering a model with the audit log.