### PR TITLE
Ignore null changeset on creation and deletion

### DIFF
--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -13,11 +13,13 @@ def log_create(sender, instance, created, **kwargs):
     if created:
         changes = model_instance_diff(None, instance)
 
-        log_entry = LogEntry.objects.log_create(
-            instance,
-            action=LogEntry.Action.CREATE,
-            changes=json.dumps(changes),
-        )
+        # Log an entry only if there are changes
+        if changes:
+            log_entry = LogEntry.objects.log_create(
+                instance,
+                action=LogEntry.Action.CREATE,
+                changes=json.dumps(changes),
+            )
 
 
 def log_update(sender, instance, **kwargs):
@@ -54,8 +56,10 @@ def log_delete(sender, instance, **kwargs):
     if instance.pk is not None:
         changes = model_instance_diff(instance, None)
 
-        log_entry = LogEntry.objects.log_create(
-            instance,
-            action=LogEntry.Action.DELETE,
-            changes=json.dumps(changes),
-        )
+        # Log an entry only if there are changes
+        if changes:
+            log_entry = LogEntry.objects.log_create(
+                instance,
+                action=LogEntry.Action.DELETE,
+                changes=json.dumps(changes),
+            )

--- a/auditlog_tests/models.py
+++ b/auditlog_tests/models.py
@@ -85,7 +85,7 @@ class SimpleIncludeModel(models.Model):
     A simple model used for register's include_fields kwarg
     """
 
-    label = models.CharField(max_length=100)
+    label = models.CharField(null=True, max_length=100)
     text = models.TextField(blank=True)
 
     history = AuditlogHistoryField()

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -200,6 +200,20 @@ class SimpeIncludeModelTest(TestCase):
         sim.save()
         self.assertTrue(sim.history.count() == 2, msg="There are two log entries")
 
+        # Create with text, ignore
+        sim = SimpleIncludeModel(text="Looong text")
+        sim.save()
+        self.assertTrue(sim.history.count() == 0, msg="There are no log entries")
+
+        # Delete, ignore
+        self.assertTrue(
+            LogEntry.objects.count() == 2, msg="There are two log entries total"
+        )
+        sim.delete()
+        self.assertTrue(
+            LogEntry.objects.count() == 2, msg="No log entry added after delete"
+        )
+
 
 class SimpeExcludeModelTest(TestCase):
     """Log only changes that are not in exclude_fields"""


### PR DESCRIPTION
## Problem
I registered a nullable field of a model using `include_fields`.  There was a a check for null `changes` in the `log_update` receiver, but not the `log_create` and `log_delete` ones.  This meant that a log entry was created with `null` for the changes field whenever a model was created or updated, but didn't have a value for that field.

When the mixin method `msg_short` is called in the Audit Log admin index, it would error because it's expecting an object for changes.

## What Changed:
* Made the SimpleIncludeModel label field nullable
* Added tests for creation and deletion of a model with a null label field
* Added checks to `log_create` and `log_delete` to make sure entries aren't created if the changes are None.