### PR TITLE
Add locale

### DIFF
--- a/auditlog/admin.py
+++ b/auditlog/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
 
 from auditlog.filters import ResourceTypeFilter
 from auditlog.mixins import LogEntryAdminMixin
@@ -19,7 +20,7 @@ class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
     readonly_fields = ["created", "resource_url", "action", "user_url", "msg"]
     fieldsets = [
         (None, {"fields": ["created", "user_url", "resource_url"]}),
-        ("Changes", {"fields": ["action", "msg"]}),
+        (_("Changes"), {"fields": ["action", "msg"]}),
     ]
 
 

--- a/auditlog/apps.py
+++ b/auditlog/apps.py
@@ -1,7 +1,11 @@
 from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
 
 
 class AuditlogConfig(AppConfig):
+    """Default configuration for auditlog app."""
+
     name = "auditlog"
-    verbose_name = "Audit log"
+    label = "auditlog"
+    verbose_name = _("Audit Log")
     default_auto_field = "django.db.models.AutoField"

--- a/auditlog/filters.py
+++ b/auditlog/filters.py
@@ -1,8 +1,9 @@
 from django.contrib.admin import SimpleListFilter
+from django.utils.translation import gettext_lazy as _
 
 
 class ResourceTypeFilter(SimpleListFilter):
-    title = "Resource Type"
+    title = _("Resource Type")
     parameter_name = "resource_type"
 
     def lookups(self, request, model_admin):

--- a/auditlog/locale/es/LC_MESSAGES/django.po
+++ b/auditlog/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,150 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-01-30 15:13-0600\n"
+"PO-Revision-Date: 2021-04-05 13:31-0400\n"
+"Last-Translator: Luis Saavedra <luis94855510@gmail.com>\n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.3\n"
+
+#: auditlog/admin.py:23 auditlog/mixins.py:61 auditlog/mixins.py:84
+msgid "Changes"
+msgstr "Cambios"
+
+#: auditlog/apps.py:10
+msgid "Audit Log"
+msgstr "Registro de Auditoría"
+
+#: auditlog/filters.py:6
+msgid "Resource Type"
+msgstr "Tipo de Recurso"
+
+#: auditlog/mixins.py:19
+msgid "Created"
+msgstr "Creado"
+
+#: auditlog/mixins.py:33
+msgid "User"
+msgstr "Usuario"
+
+#: auditlog/mixins.py:48
+msgid "Resource"
+msgstr "Recurso"
+
+#: auditlog/mixins.py:69
+msgid "Field"
+msgstr "Campo"
+
+#: auditlog/mixins.py:70
+msgid "From"
+msgstr "De"
+
+#: auditlog/mixins.py:71
+msgid "To"
+msgstr "A"
+
+#: auditlog/models.py:197
+msgid "create"
+msgstr "creado"
+
+#: auditlog/models.py:198
+msgid "update"
+msgstr "actualizado"
+
+#: auditlog/models.py:199
+msgid "delete"
+msgstr "eliminado"
+
+#: auditlog/models.py:206
+msgid "content type"
+msgstr "tipo de contenido"
+
+#: auditlog/models.py:209
+msgid "object pk"
+msgstr "pk del objeto"
+
+#: auditlog/models.py:212
+msgid "object id"
+msgstr "id del objeto"
+
+#: auditlog/models.py:214
+msgid "object representation"
+msgstr "representación del objeto"
+
+#: auditlog/models.py:216
+msgid "action"
+msgstr "acción"
+
+#: auditlog/models.py:218
+msgid "change message"
+msgstr "mensaje de cambios"
+
+#: auditlog/models.py:225
+msgid "actor"
+msgstr "actor"
+
+#: auditlog/models.py:228
+msgid "remote address"
+msgstr "dirección remota"
+
+#: auditlog/models.py:230
+msgid "timestamp"
+msgstr "marca de tiempo"
+
+#: auditlog/models.py:232
+msgid "additional data"
+msgstr "datos adicionales"
+
+#: auditlog/models.py:240
+msgid "log entry"
+msgstr "entrada de registro"
+
+#: auditlog/models.py:241
+msgid "log entries"
+msgstr "entradas de registro"
+
+#: auditlog/models.py:245
+msgid "Created {repr:s}"
+msgstr "Creado {repr:s}"
+
+#: auditlog/models.py:247
+msgid "Updated {repr:s}"
+msgstr "Actualizado {repr:s}"
+
+#: auditlog/models.py:249
+msgid "Deleted {repr:s}"
+msgstr "Eliminado {repr:s}"
+
+#: auditlog/models.py:251
+msgid "Logged {repr:s}"
+msgstr "Registrado {repr:s}"
+
+#~ msgid "Deletes all log entries from the database."
+#~ msgstr "Eliminar todas las entradas de registro de la base de datos."
+
+#~ msgid "Continue without asking confirmation."
+#~ msgstr "Continuar sin pedir confirmación."
+
+#~ msgid "This action will clear all log entries from the database."
+#~ msgstr ""
+#~ "Esta acción borrará todas las entradas del registro de la base de datos."
+
+#~ msgid "Are you sure you want to continue?"
+#~ msgstr "¿Estás seguro de que quieres continuar?"
+
+#~ msgid "Deleted %d objects."
+#~ msgstr "%d objetos eliminados."
+
+#~ msgid "Aborted."
+#~ msgstr "Abortado."

--- a/auditlog/mixins.py
+++ b/auditlog/mixins.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.urls.exceptions import NoReverseMatch
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
 
 from auditlog.models import LogEntry
 
@@ -15,7 +16,7 @@ class LogEntryAdminMixin:
     def created(self, obj):
         return obj.timestamp.strftime("%Y-%m-%d %H:%M:%S")
 
-    created.short_description = "Created"
+    created.short_description = _("Created")
 
     def user_url(self, obj):
         if obj.actor:
@@ -29,7 +30,7 @@ class LogEntryAdminMixin:
 
         return "system"
 
-    user_url.short_description = "User"
+    user_url.short_description = _("User")
 
     def resource_url(self, obj):
         app_label, model = obj.content_type.app_label, obj.content_type.model
@@ -44,7 +45,7 @@ class LogEntryAdminMixin:
                 '<a href="{}">{} - {}</a>', link, obj.content_type, obj.object_repr
             )
 
-    resource_url.short_description = "Resource"
+    resource_url.short_description = _("Resource")
 
     def msg_short(self, obj):
         if obj.action == LogEntry.Action.DELETE:
@@ -57,13 +58,18 @@ class LogEntryAdminMixin:
             fields = fields[:i] + " .."
         return "%d change%s: %s" % (len(changes), s, fields)
 
-    msg_short.short_description = "Changes"
+    msg_short.short_description = _("Changes")
 
     def msg(self, obj):
         if obj.action == LogEntry.Action.DELETE:
             return ""  # delete
         changes = json.loads(obj.changes)
-        msg = "<table><tr><th>#</th><th>Field</th><th>From</th><th>To</th></tr>"
+        msg = format_html(
+            "<table><tr><th>#</th><th>{}</th><th>{}</th><th>{}</th></tr>",
+            _("Field"),
+            _("From"),
+            _("To"),
+        )
         for i, field in enumerate(sorted(changes), 1):
             value = [i, field] + (
                 ["***", "***"] if field == "password" else changes[field]
@@ -75,4 +81,4 @@ class LogEntryAdminMixin:
         msg += "</table>"
         return mark_safe(msg)
 
-    msg.short_description = "Changes"
+    msg.short_description = _("Changes")

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
         "auditlog.management",
         "auditlog.management.commands",
     ],
+    package_data={
+        "auditlog": ["locale/*/LC_MESSAGES/*.po", "locale/*/LC_MESSAGES/*.mo"],
+    },
     url="https://github.com/jazzband/django-auditlog",
     project_urls={
         "Documentation": "https://django-auditlog.readthedocs.io",


### PR DESCRIPTION
Added locale to translate app in admin. Also I'm added two additional files:

 - manage.py
 - app.py

`app.py` is needed only to translate the app-name, in the other hand `manage.py` is added to generate translation .po file in other language with django tools, for example with:
```console
$ python manage.py makemessages --locale fr
```
it is generates .po french file translation,

regards,
Luis