### PR TITLE
change dict.iteritems to dict.items 

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -135,7 +135,7 @@ The :py:class:`AuditlogHistoryField` provides easy access to :py:class:`LogEntry
           </tr>
         </thead>
         <tbody>
-        {% for key, value in mymodel.history.latest.changes_dict.iteritems %}
+        {% for key, value in mymodel.history.latest.changes_dict.items %}
           <tr>
             <td>{{ key }}</td>
             <td>{{ value.0|default:"None" }}</td>


### PR DESCRIPTION
dict.iteritems was removed from python 3. See [PEP 469](https://www.python.org/dev/peps/pep-0469/)