### PR TITLE
Pin psycopg2 to version compatible with Django 2.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     # Test requirements
     coverage
     codecov
-    psycopg2-binary
+    psycopg2-binary>=2.8,<2.9
 passenv=
     TEST_DB_HOST
     TEST_DB_USER


### PR DESCRIPTION
See https://github.com/psycopg/psycopg2/issues/1293#issuecomment-862835147. Without this change, all CI tests fail on the current master branch.