### PR TITLE
Apply default_auto_field to app config.

### DIFF
--- a/auditlog/apps.py
+++ b/auditlog/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class AuditlogConfig(AppConfig):
     name = "auditlog"
     verbose_name = "Audit log"
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
Developers who have set `DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'` in settings.py, and have django-auditlog installed, will be prompted to create a migration to migrate the Id field of LogeEntry to BigAutoField.

This PR sets the default_auto_field in the app config to match what is expressed in [0001_initial.py](https://github.com/jazzband/django-auditlog/blob/master/auditlog/migrations/0001_initial.py#L19), avoiding the nag for a potentially dangerous migration.

Related Issue: [#247](https://github.com/jazzband/django-auditlog/issues/247)