### PR TITLE
Return default value None if attribute choices doesn't exist

### DIFF
--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -310,7 +310,7 @@ class LogEntry(models.Model):
             values_display = []
             # handle choices fields and Postgres ArrayField to get human readable version
             choices_dict = None
-            if getattr(field, "choices") and len(field.choices) > 0:
+            if getattr(field, "choices", None) and len(field.choices) > 0:
                 choices_dict = dict(field.choices)
             if (
                 hasattr(field, "base_field")


### PR DESCRIPTION
Related to #273 and #293 

Very minimal change that should have no impact on the code other than making sure iterated fields have a .choices attribute.