### PR TITLE
Replace ugettext with gettext for django4 compatibility

### DIFF
--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -11,7 +11,7 @@ from django.db import DEFAULT_DB_ALIAS, models
 from django.db.models import Field, Q, QuerySet
 from django.utils import formats, timezone
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jsonfield.fields import JSONField
 
 


### PR DESCRIPTION
This should be a "in-place-replacement" with hopefully no side effects, would be great to have it in the pre-release package, for example as 1.0a2 :) 

This should fix #334 