### PR TITLE
build(python): remove python 3.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     services:
       postgres:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 # Docs requirements
+django>=3.2,<3.3
 sphinx
 sphinx_rtd_theme
 psycopg2-binary

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,10 +11,10 @@ The repository can be found at https://github.com/jazzband/django-auditlog/.
 
 **Requirements**
 
-- Python 3.6 or higher
+- Python 3.7 or higher
 - Django 2.2 or higher
 
-Auditlog is currently tested with Python 3.6 - 3.8 and Django 2.2, 3.1 and 3.2. The latest test report can be found
+Auditlog is currently tested with Python 3.7 - 3.8 and Django 2.2, 3.1 and 3.2. The latest test report can be found
 at https://github.com/jazzband/django-auditlog/actions.
 
 Adding Auditlog to your Django application

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py36"]
+target-version = ["py37"]
 
 # black compatible isort
 [tool.isort]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     zip_safe=False,
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py37,py38,py39}-django-{22,31}
+    {py37,py38,py39}-django{22,31}
     {py37,py38,py39,py10}-django32
     py38-docs
     py38-qa
@@ -10,9 +10,9 @@ commands =
     coverage run --source auditlog runtests.py
     coverage xml
 deps =
-    django-22: Django>=2.2,<2.3
-    django-31: Django>=3.1,<3.2
-    django-32: Django>=3.2,<3.3
+    django22: Django>=2.2,<2.3
+    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
     # Test requirements
     coverage
     codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py36,py37,py38,py39}-django-{22,31}
-    {py36,py37,py38,py39,py10}-django32
+    {py37,py38,py39}-django-{22,31}
+    {py37,py38,py39,py10}-django32
     py38-docs
     py38-qa
 
@@ -29,7 +29,6 @@ basepython =
     py39: python3.9
     py38: python3.8
     py37: python3.7
-    py36: python3.6
 
 [testenv:py38-docs]
 changedir = docs/source
@@ -47,7 +46,6 @@ commands =
 
 [gh-actions]
 python =
-  3.6: py36
   3.7: py37
   3.8: py38
   3.9: py39


### PR DESCRIPTION
Python 3.6 reaches end of life in December 2021.

This PR fixes CI too.