### PR TITLE
build: replace django-jsonfield with django-jsonfield-backport

### DIFF
--- a/auditlog/migrations/0005_logentry_additional_data_verbose_name.py
+++ b/auditlog/migrations/0005_logentry_additional_data_verbose_name.py
@@ -1,5 +1,5 @@
-import jsonfield.fields
 from django.db import migrations, models
+from django_jsonfield_backport.models import JSONField
 
 
 class Migration(migrations.Migration):
@@ -12,8 +12,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="logentry",
             name="additional_data",
-            field=jsonfield.fields.JSONField(
-                null=True, verbose_name="additional data", blank=True
-            ),
+            field=JSONField(null=True, verbose_name="additional data", blank=True),
         ),
     ]

--- a/auditlog/migrations/0009_alter_logentry_additional_data.py
+++ b/auditlog/migrations/0009_alter_logentry_additional_data.py
@@ -1,17 +1,17 @@
-from django.db import migrations, models
+from django.db import migrations
 from django_jsonfield_backport.models import JSONField
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("auditlog", "0003_logentry_remote_addr"),
+        ("auditlog", "0008_action_index"),
     ]
 
     operations = [
-        migrations.AddField(
+        migrations.AlterField(
             model_name="logentry",
             name="additional_data",
-            field=JSONField(null=True, blank=True),
+            field=JSONField(blank=True, null=True, verbose_name="additional data"),
         ),
     ]

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -12,7 +12,7 @@ from django.db.models import Field, Q, QuerySet
 from django.utils import formats, timezone
 from django.utils.encoding import smart_str
 from django.utils.translation import ugettext_lazy as _
-from jsonfield.fields import JSONField
+from django_jsonfield_backport.models import JSONField
 
 
 class LogEntryManager(models.Manager):

--- a/auditlog_tests/test_settings.py
+++ b/auditlog_tests/test_settings.py
@@ -14,6 +14,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.admin",
     "django.contrib.staticfiles",
+    "django_jsonfield_backport",
     "auditlog",
     "auditlog_tests",
 ]

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 
 import django
 from dateutil.tz import gettz
@@ -330,12 +329,7 @@ class AdditionalDataModelTest(TestCase):
             obj_with_additional_data.history.count() == 1, msg="There is 1 log entry"
         )
         log_entry = obj_with_additional_data.history.get()
-        # FIXME: Work-around for the fact that additional_data isn't working
-        # on Django 3.1 correctly (see https://github.com/jazzband/django-auditlog/issues/266)
-        if django.VERSION >= (3, 1):
-            extra_data = json.loads(log_entry.additional_data)
-        else:
-            extra_data = log_entry.additional_data
+        extra_data = log_entry.additional_data
         self.assertIsNotNone(extra_data)
         self.assertTrue(
             extra_data["related_model_text"] == related_model.text,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     description="Audit log app for Django",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=["django-jsonfield>=1.0.0", "python-dateutil>=2.6.0"],
+    install_requires=["django-jsonfield-backport>=1.0.0", "python-dateutil>=2.6.0"],
     zip_safe=False,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
The `django-jsonfield` module is not maintained anymore and raises some errors with Django 4.0. So, as a recommendation in this package, and as Django 2.2 is still maintained, `django-jsonfield-backport` will do the job for the `JSONField` field.

Ref #43
Ref #334

PS: this PR is another try to solve what #271 is solving, but by keeping the `JSONField` field.
PPS: `django-jsonfield-backport` will be removed when Django 2.2 will be end of life (Django supports `JSONField` since 3.1).