### PR TITLE
docs(conf): replace pkg_resources with importlib

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 import os
 import sys
 from datetime import date
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
 # -- Path setup --------------------------------------------------------------
 
@@ -31,7 +31,7 @@ project = 'django-auditlog'
 author = 'Jan-Jelle Kester and contributors'
 copyright = f'2013-{date.today().year}, {author}'
 
-release = get_distribution('django-auditlog').version
+release = version('django-auditlog')
 # for example take major/minor
 version = '.'.join(release.split('.')[:2])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 target-version = ["py37"]
 


### PR DESCRIPTION
The doc is build with python 3.8, which includes the `importlib` API to get the package version. Its use is recommanded by `setuptools-scm` for the doc.