### PR TITLE
Add django-jsonfield-backport to docs/requirements.txt to fix docs build.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ django>=3.2,<3.3
 sphinx
 sphinx_rtd_theme
 psycopg2-binary
+django-jsonfield-backport>=1.0.0


### PR DESCRIPTION
The `tox -e py38-docs` now fails with the following error:

```
Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "jazzband/django-auditlog/.tox/py38-docs/lib/python3.8/site-packages/sphinx/config.py", line 329, in eval_config_file
    exec(code, namespace)
  File "jazzband/django-auditlog/docs/source/conf.py", line 26, in <module>
    django.setup()
  File "jazzband/django-auditlog/.tox/py38-docs/lib/python3.8/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "work/jazzband/django-auditlog/.tox/py38-docs/lib/python3.8/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "jazzband/django-auditlog/.tox/py38-docs/lib/python3.8/site-packages/django/apps/config.py", line 223, in create
    import_module(entry)
  File ".pyenv/versions/3.8.0/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'django_jsonfield_backport'
```