### PR TITLE
enable use of replica database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changes
 
-### Improvements
+#### Improvements
 - feat: enable use of replica database (delegating the choice to `DATABASES_ROUTER`) ([#359](https://github.com/jazzband/django-auditlog/pull/359))
 
-### Important notes
+#### Important notes
 - LogEntry no longer save to same database instance is using
 
 ## 1.0.0 (2022-01-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changes
 
+### Improvements
+- feat: enable use of replica database (delegating the choice to `DATABASES_ROUTER`) ([#359](https://github.com/jazzband/django-auditlog/pull/359))
+
+### Important notes
+- LogEntry no longer save to same database instance is using
+
 ## 1.0.0 (2022-01-24)
 
 ### Final
 
 #### Improvements
 
-- feat: enable use of replica database (delegating the choice to `DATABASES_ROUTER`) ([#359](https://github.com/jazzband/django-auditlog/pull/359))
 - build: add classifiers for Python and Django
 - build: replace django-jsonfield with django-jsonfield-backport ([#339](https://github.com/jazzband/django-auditlog/pull/339))
 - ci: replace Travis with Github Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Improvements
 
+- feat: enable use of replica database (delegating the choice to `DATABASES_ROUTER`) ([#359](https://github.com/jazzband/django-auditlog/pull/359))
 - build: add classifiers for Python and Django
 - build: replace django-jsonfield with django-jsonfield-backport ([#339](https://github.com/jazzband/django-auditlog/pull/339))
 - ci: replace Travis with Github Actions

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -67,13 +67,7 @@ class LogEntryManager(models.Manager):
                         content_type=kwargs.get("content_type"),
                         object_pk=kwargs.get("object_pk", ""),
                     ).delete()
-            # save LogEntry to same database instance is using
-            db = instance._state.db
-            return (
-                self.create(**kwargs)
-                if db is None or db == ""
-                else self.using(db).create(**kwargs)
-            )
+            return self.create(**kwargs)
         return None
 
     def get_for_object(self, instance):

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -11,7 +11,6 @@ from django.db.models.signals import pre_save
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 from django.utils import dateformat, formats, timezone
-from django.utils.connection import ConnectionDoesNotExist
 
 from auditlog.diff import model_instance_diff
 from auditlog.middleware import AuditlogMiddleware
@@ -151,6 +150,25 @@ class SimpleModelTest(TestCase):
         SimpleModel.objects.all().delete()
         self.setUp()
         self.test_create()
+
+    def test_create_log_to_object_from_other_database(self):
+        msg = "The log should not try to write to the same database as the object"
+
+        instance = self.obj
+        instance._state.db = (
+            "replica"  # simulate object obtained from a different database (read only)
+        )
+
+        changes = model_instance_diff(None, instance)
+
+        log_entry = LogEntry.objects.log_create(
+            instance,
+            action=LogEntry.Action.CREATE,
+            changes=json.dumps(changes),
+        )
+        self.assertEqual(
+            log_entry._state.db, "default", msg=msg
+        )  # must be created in default database
 
 
 class AltPrimaryKeyModelTest(SimpleModelTest):
@@ -923,31 +941,3 @@ class NoDeleteHistoryTest(TestCase):
             list(entries.values_list("action", flat=True)),
             [LogEntry.Action.CREATE, LogEntry.Action.UPDATE, LogEntry.Action.DELETE],
         )
-
-
-class ModelFromDifferentDatabase(TestCase):
-    """
-    Should use the default database even when object is from other database (read-only, for example)
-    """
-    def setUp(self):
-        self.obj = SimpleModel.objects.create(text="42 is the answer")
-
-    def test_create_log_to_object_from_other_database(self):
-        msg = "The log should not try to write to the same database as the object"
-
-        instance = self.obj
-        instance._state.db = 'replica'  # simulate object obtained from a different database (read only)
-
-        changes = model_instance_diff(None, instance)
-
-        try:
-            log_entry = LogEntry.objects.log_create(
-                instance,
-                action=LogEntry.Action.CREATE,
-                changes=json.dumps(changes),
-            )
-            self.assertEqual(log_entry._state.db, "default", msg=msg)  # must be created in default database
-        except ConnectionDoesNotExist as e:
-            self.assertTrue(False, msg=msg)
-
-

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -155,9 +155,8 @@ class SimpleModelTest(TestCase):
         msg = "The log should not try to write to the same database as the object"
 
         instance = self.obj
-        instance._state.db = (
-            "replica"  # simulate object obtained from a different database (read only)
-        )
+       # simulate object obtained from a different database (read only)
+        instance._state.db = "replica"
 
         changes = model_instance_diff(None, instance)
 

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -155,7 +155,7 @@ class SimpleModelTest(TestCase):
         msg = "The log should not try to write to the same database as the object"
 
         instance = self.obj
-       # simulate object obtained from a different database (read only)
+        # simulate object obtained from a different database (read only)
         instance._state.db = "replica"
 
         changes = model_instance_diff(None, instance)

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 import django
 from dateutil.tz import gettz
@@ -10,7 +11,9 @@ from django.db.models.signals import pre_save
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 from django.utils import dateformat, formats, timezone
+from django.utils.connection import ConnectionDoesNotExist
 
+from auditlog.diff import model_instance_diff
 from auditlog.middleware import AuditlogMiddleware
 from auditlog.models import LogEntry
 from auditlog.registry import auditlog
@@ -920,3 +923,31 @@ class NoDeleteHistoryTest(TestCase):
             list(entries.values_list("action", flat=True)),
             [LogEntry.Action.CREATE, LogEntry.Action.UPDATE, LogEntry.Action.DELETE],
         )
+
+
+class ModelFromDifferentDatabase(TestCase):
+    """
+    Should use the default database even when object is from other database (read-only, for example)
+    """
+    def setUp(self):
+        self.obj = SimpleModel.objects.create(text="42 is the answer")
+
+    def test_create_log_to_object_from_other_database(self):
+        msg = "The log should not try to write to the same database as the object"
+
+        instance = self.obj
+        instance._state.db = 'replica'  # simulate object obtained from a different database (read only)
+
+        changes = model_instance_diff(None, instance)
+
+        try:
+            log_entry = LogEntry.objects.log_create(
+                instance,
+                action=LogEntry.Action.CREATE,
+                changes=json.dumps(changes),
+            )
+            self.assertEqual(log_entry._state.db, "default", msg=msg)  # must be created in default database
+        except ConnectionDoesNotExist as e:
+            self.assertTrue(False, msg=msg)
+
+


### PR DESCRIPTION
When you use replica database the django-auditlog try to write in the same database where object was read (replica). But this is a read only database and crash the application.

With this changes it saves always in the default database.

If you want to save in multiple databases or in a special one use `DATABASE_ROUTERS` to configure it.

To continue using multiple databases, you must configure it in your DATABASE ROUTERS. 