### PR TITLE
Add register model using Django settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 2.0.0 (2022-05-09)
 
 #### Improvements
+- feat: Add register model from settings ([#368](https://github.com/jazzband/django-auditlog/pull/368))
 - feat: enable use of replica database (delegating the choice to `DATABASES_ROUTER`) ([#359](https://github.com/jazzband/django-auditlog/pull/359))
 - Add `mask_fields` argument in `register` to mask sensitive information when logging ([#310](https://github.com/jazzband/django-auditlog/pull/310))
 - Django: Drop 2.2 support. `django_jsonfield_backport` is not required anymore ([#370](https://github.com/jazzband/django-auditlog/pull/370))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+#### Improvements
+
+- feat: Add register model from settings ([#368](https://github.com/jazzband/django-auditlog/pull/368))
+
 #### Fixes
 
 - Fix inconsistent changes with JSONField ([#355](https://github.com/jazzband/django-auditlog/pull/355))
@@ -7,7 +11,6 @@
 ## 2.0.0 (2022-05-09)
 
 #### Improvements
-- feat: Add register model from settings ([#368](https://github.com/jazzband/django-auditlog/pull/368))
 - feat: enable use of replica database (delegating the choice to `DATABASES_ROUTER`) ([#359](https://github.com/jazzband/django-auditlog/pull/359))
 - Add `mask_fields` argument in `register` to mask sensitive information when logging ([#310](https://github.com/jazzband/django-auditlog/pull/310))
 - Django: Drop 2.2 support. `django_jsonfield_backport` is not required anymore ([#370](https://github.com/jazzband/django-auditlog/pull/370))

--- a/auditlog/apps.py
+++ b/auditlog/apps.py
@@ -7,6 +7,6 @@ class AuditlogConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
-        from .registry import auditlog_register, auditlog
+        from .registry import auditlog, auditlog_register
 
         auditlog_register(auditlog)

--- a/auditlog/apps.py
+++ b/auditlog/apps.py
@@ -5,3 +5,8 @@ class AuditlogConfig(AppConfig):
     name = "auditlog"
     verbose_name = "Audit log"
     default_auto_field = "django.db.models.AutoField"
+
+    def ready(self):
+        from .registry import auditlog_register, auditlog
+
+        auditlog_register(auditlog)

--- a/auditlog/apps.py
+++ b/auditlog/apps.py
@@ -7,6 +7,6 @@ class AuditlogConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
-        from .registry import auditlog, auditlog_register
+        from auditlog.registry import auditlog
 
-        auditlog_register(auditlog)
+        auditlog.register_from_settings()

--- a/auditlog/conf.py
+++ b/auditlog/conf.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+
+# Register all models when set to True
+settings.AUDITLOG_INCLUDE_ALL_MODELS = getattr(
+    settings, "AUDITLOG_INCLUDE_ALL_MODELS", False
+)
+
+# Exclude models in registration process
+# It will be considered when `AUDITLOG_INCLUDE_ALL_MODELS` is True
+settings.AUDITLOG_EXCLUDE_TRACKING_MODELS = getattr(
+    settings, "AUDITLOG_EXCLUDE_TRACKING_MODELS", ()
+)
+
+# Register models and define their logging behaviour
+settings.AUDITLOG_INCLUDE_TRACKING_MODELS = getattr(
+    settings, "AUDITLOG_INCLUDE_TRACKING_MODELS", ()
+)

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -193,7 +193,7 @@ def _auditlog_register_models(
             except IndexError:
                 pass
         else:
-            raise TypeError(f"item must be a dict or str")
+            raise TypeError("item must be a dict or str")
 
 
 def get_exclude_models():

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -186,12 +186,10 @@ def _auditlog_register_models(
                 raise ValueError(
                     "model with options must be in the format <app_name>.<model_name>"
                 )
-            try:
-                model["model"] = _get_model_classes(model["model"])[0]
-                auditlog.unregister(model["model"])
-                auditlog.register(**model)
-            except IndexError:
-                pass
+
+            model["model"] = _get_model_classes(model["model"])[0]
+            auditlog.unregister(model["model"])
+            auditlog.register(**model)
         else:
             raise TypeError("item must be a dict or str")
 

--- a/auditlog_tests/test_settings.py
+++ b/auditlog_tests/test_settings.py
@@ -59,3 +59,26 @@ ROOT_URLCONF = "auditlog_tests.urls"
 USE_TZ = True
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+
+AUDITLOG_INCLUDE_ALL_MODELS = False
+AUDITLOG_INCLUDE_TRACKING_MODELS = (
+    "auditlog_tests.SimpleModel",
+    {
+        "model": "auditlog_tests.SimpleExcludeModel",
+        "exclude_fields": ["text"],
+    },
+    {
+        "model": "auditlog_tests.SimpleIncludeModel",
+        "include_fields": ["label"],
+    },
+    {
+        "model": "auditlog_tests.SimpleMappingModel",
+        "mapping_fields": {"sku": "Product No."},
+    },
+    {
+        "model": "auditlog_tests.SimpleMaskedModel",
+        "mask_fields": ["address"],
+    },
+)
+AUDITLOG_EXCLUDE_TRACKING_MODELS = ()

--- a/auditlog_tests/test_settings.py
+++ b/auditlog_tests/test_settings.py
@@ -59,26 +59,3 @@ ROOT_URLCONF = "auditlog_tests.urls"
 USE_TZ = True
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
-
-
-AUDITLOG_INCLUDE_ALL_MODELS = False
-AUDITLOG_INCLUDE_TRACKING_MODELS = (
-    "auditlog_tests.SimpleModel",
-    {
-        "model": "auditlog_tests.SimpleExcludeModel",
-        "exclude_fields": ["text"],
-    },
-    {
-        "model": "auditlog_tests.SimpleIncludeModel",
-        "include_fields": ["label"],
-    },
-    {
-        "model": "auditlog_tests.SimpleMappingModel",
-        "mapping_fields": {"sku": "Product No."},
-    },
-    {
-        "model": "auditlog_tests.SimpleMaskedModel",
-        "mask_fields": ["address"],
-    },
-)
-AUDITLOG_EXCLUDE_TRACKING_MODELS = ()

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -19,11 +19,11 @@ from auditlog.middleware import AuditlogMiddleware
 from auditlog.models import LogEntry
 from auditlog.registry import (
     AuditlogModelRegistry,
+    _auditlog_register_models,
+    _get_model_classes,
     auditlog,
     auditlog_register,
     get_exclude_models,
-    _get_model_classes,
-    _auditlog_register_models,
 )
 from auditlog_tests.models import (
     AdditionalDataIncludedModel,

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -810,12 +810,19 @@ class RegisterAllModels(TestCase):
             self.test_auditlog.unregister(model)
 
     def test_auditlog_register_models(self):
-        with self.assertRaises(TypeError):
+        value = "no list"
+        with self.assertRaisesMessage(
+            TypeError, f"models'({type(value)}) is not an list or tuple"
+        ):
             _auditlog_register_models(self.test_auditlog, "no list")
-        with self.assertRaises(TypeError):
+
+        value = {}
+        with self.assertRaisesMessage(
+            TypeError, f"models'({type(value)}) is not an list or tuple"
+        ):
             _auditlog_register_models(self.test_auditlog, {})
 
-        with self.assertRaises(ValueError):
+        with self.assertRaisesMessage(ValueError, "item must contain 'model' key"):
             # must include the model key.
             _auditlog_register_models(
                 self.test_auditlog,
@@ -827,7 +834,10 @@ class RegisterAllModels(TestCase):
                 ),
             )
 
-        with self.assertRaises(ValueError):
+        with self.assertRaisesMessage(
+            ValueError,
+            "model with options must be in the format <app_name>.<model_name>",
+        ):
             # It should take the format `<app_name>.< model_name>``
             _auditlog_register_models(
                 self.test_auditlog,
@@ -839,7 +849,7 @@ class RegisterAllModels(TestCase):
                 ),
             )
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesMessage(TypeError, "item must be a dict or str"):
             # models item must be a dict or str
             _auditlog_register_models(self.test_auditlog, (1, 2, 3, 4))
 

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 import json
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -91,6 +91,55 @@ For example, to mask the field ``address``, use::
 
     Masking fields
 
+Settings
+--------
+
+You can register a model using Django settings variables in `settings.py`, as the following example
+
+**AUDITLOG_INCLUDE_ALL_MODELS**
+
+.. code-block:: python
+
+    # Django project settings.py
+
+    # register all models.
+    AUDITLOG_INCLUDE_ALL_MODELS=True
+
+**AUDITLOG_INCLUDE_TRACKING_MODELS**
+
+.. code-block:: python
+
+    # Django project settings.py
+
+    # assign models to register. this has the same behavior as auditlog.register()
+    AUDITLOG_INCLUDE_TRACKING_MODELS = (
+        "<appname>.<model1>",
+        {
+            "model": "<appname>.<model1>",
+            "include_fields": ["field1", "field2"],
+            "exclude_fields": ["field3", "field4"],
+            "mapping_fields": {
+                "field1": "FIELD",
+            },
+            "mask_fields": ["field5", "field6"],
+        },
+        "<appname>.<model3>",
+    )
+
+**AUDITLOG_EXCLUDE_TRACKING_MODELS**
+
+
+.. code-block:: python
+
+    # Django project settings.py
+
+    # assign models to exclude. this option is executed when
+    # AUDITLOG_INCLUDE_ALL_MODELS value is True.
+    AUDITLOG_EXCLUDE_TRACKING_MODELS = (
+        "<app_name>",
+        "<app_name>.<model>"
+    )
+
 Actors
 ------
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -91,27 +91,44 @@ For example, to mask the field ``address``, use::
 
     Masking fields
 
+
 Settings
 --------
 
-You can register a model using Django settings variables in `settings.py`, as the following example
-
 **AUDITLOG_INCLUDE_ALL_MODELS**
+
+You can use this setting to register all your models:
 
 .. code-block:: python
 
-    # Django project settings.py
-
-    # register all models.
     AUDITLOG_INCLUDE_ALL_MODELS=True
+
+.. versionadded:: 2.1.0
+
+**AUDITLOG_EXCLUDE_TRACKING_MODELS**
+
+You can use this setting to exclude models in registration process.
+It will be considered when ``AUDITLOG_INCLUDE_ALL_MODELS`` is `True`.
+
+.. code-block:: python
+
+    AUDITLOG_EXCLUDE_TRACKING_MODELS = (
+        "<app_name>",
+        "<app_name>.<model>"
+    )
+
+.. versionadded:: 2.1.0
 
 **AUDITLOG_INCLUDE_TRACKING_MODELS**
 
+You can use this setting to configure your models registration and other behaviours.
+It must be a list or tuple. Each item in this setting can be a:
+
+* ``str``: To register a model.
+* ``dict``: To register a model and define its logging behaviour. e.g. include_fields, exclude_fields.
+
 .. code-block:: python
 
-    # Django project settings.py
-
-    # assign models to register. this has the same behavior as auditlog.register()
     AUDITLOG_INCLUDE_TRACKING_MODELS = (
         "<appname>.<model1>",
         {
@@ -126,19 +143,7 @@ You can register a model using Django settings variables in `settings.py`, as th
         "<appname>.<model3>",
     )
 
-**AUDITLOG_EXCLUDE_TRACKING_MODELS**
-
-
-.. code-block:: python
-
-    # Django project settings.py
-
-    # assign models to exclude. this option is executed when
-    # AUDITLOG_INCLUDE_ALL_MODELS value is True.
-    AUDITLOG_EXCLUDE_TRACKING_MODELS = (
-        "<app_name>",
-        "<app_name>.<model>"
-    )
+.. versionadded:: 2.1.0
 
 Actors
 ------


### PR DESCRIPTION
This PR makes it easy to register model in the django-auditlog.

## Setting variable

`AUDITLOG_INCLUDE_ALL_MODELS` 
-> registers all models loaded from the django instance. 
```python
from django.apps import apps

apps.get_models()
```

e.g)
```python
# The code below means to register all models.
AUDITLOG_INCLUDE_ALL_MODELS=True
```

`AUDITLOG_INCLUDE_TRACKING_MODELS` 
-> assign models to register.  this has the same behavior as `audit log.register()`

e.g)
```python
AUDITLOG_INCLUDE_TRACKING_MODELS = (
    "<appname>.<model1>",
    {
        "model": "<appname>.<model1>",
        "include_fields": ["field1", "field2"],
        "exclude_fields": ["field3", "field4"],
        "mapping_fields": {
            "field1": "FIELD",
        },
        "mask_fields": ["field5", "field6"],
    },
    "<appname>.<model3>",
)
```


`AUDITLOG_EXCLUDE_TRACKING_MODELS` 
-> assign models to exclude. this option is executed when `AUDITLOG_INCLUDE_ALL_MODELS` value is True.

e.g)
```python
AUDITLOG_EXCLUDE_TRACKING_MODELS = (
    "<app_name>",
    "<app_name>.<model>"
)
```


