### PR TITLE
Revert "build: explicit the build system"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
-build-backend = "setuptools.build_meta"
-
 [tool.black]
 target-version = ["py37"]
 


### PR DESCRIPTION
This reverts commit 7bc39e6d9d51e7321bfca8793e21b8066d9859d3.

After this change the [readthedoc builds failed](https://readthedocs.org/projects/django-auditlog/builds/15827195/) because it uses python 3.7