### PR TITLE
Disable `add` button in admin ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Fixes
 
 - Fix inconsistent changes with JSONField ([#355](https://github.com/jazzband/django-auditlog/pull/355))
+- Disable `add` button in admin ui ([#378](https://github.com/jazzband/django-auditlog/pull/378))
 
 ## 2.0.0 (2022-05-09)
 

--- a/auditlog/admin.py
+++ b/auditlog/admin.py
@@ -22,5 +22,9 @@ class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
         ("Changes", {"fields": ["action", "msg"]}),
     ]
 
+    def has_add_permission(self, request):
+        # As audit admin doesn't allow log creation from admin
+        return False
+
 
 admin.site.register(LogEntry, LogEntryAdmin)

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -933,7 +933,7 @@ class AdminPanelTest(TestCase):
         res = self.client.get("/admin/auditlog/logentry/")
         assert res.status_code == 200
         res = self.client.get("/admin/auditlog/logentry/add/")
-        assert res.status_code == 200
+        assert res.status_code == 403
         res = self.client.get(f"/admin/auditlog/logentry/{log_pk}/", follow=True)
         assert res.status_code == 200
         res = self.client.get(f"/admin/auditlog/logentry/{log_pk}/delete/")


### PR DESCRIPTION
Refresh https://github.com/jazzband/django-auditlog/pull/171