### PR TITLE
Fix & improve running tests with tox

### DIFF
--- a/auditlog_tests/test_settings.py
+++ b/auditlog_tests/test_settings.py
@@ -29,7 +29,9 @@ MIDDLEWARE = (
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.getenv("TEST_DB_NAME", "auditlog_tests_db"),
+        "NAME": os.getenv(
+            "TEST_DB_NAME", "auditlog" + os.environ.get("TOX_PARALLEL_ENV", "")
+        ),
         "USER": os.getenv("TEST_DB_USER", "postgres"),
         "PASSWORD": os.getenv("TEST_DB_PASS", ""),
         "HOST": os.getenv("TEST_DB_HOST", "127.0.0.1"),

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1,6 +1,7 @@
 import datetime
 import itertools
 import json
+import warnings
 from unittest import mock
 
 from dateutil.tz import gettz
@@ -599,6 +600,18 @@ class DateTimeFieldModelTest(TestCase):
 
     utc_plus_one = timezone.get_fixed_timezone(datetime.timedelta(hours=1))
     now = timezone.now()
+
+    def setUp(self):
+        super().setUp()
+        self._context = warnings.catch_warnings()
+        self._context.__enter__()
+        warnings.filterwarnings(
+            "ignore", message=".*naive datetime", category=RuntimeWarning
+        )
+
+    def tearDown(self):
+        self._context.__exit__()
+        super().tearDown()
 
     def test_model_with_same_time(self):
         timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py37,py38,py39,py10}-django32
-    {py38,py39,py10}-django{40,main}
+    {py37,py38,py39,py310}-django32
+    {py38,py39,py310}-django{40,main}
     py37-docs
     py38-lint
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist =
     py38-lint
 
 [testenv]
+setenv =
+  COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 commands =
     coverage run --source auditlog runtests.py
     coverage xml


### PR DESCRIPTION
There are three unrelated fixes and improvements in this pull request:
1. A typo in tox env list is fixed.
2. An expected warning is silenced in the tests.
3. Test configuration is adjusted to allow running `tox -p`.

The third item improves the total duration of tests (as measured by `time`) on the local machine drastically:

| command | sequential (no `-p` flag) | parallel (with `-p` flag) |
|----------|---------------------------|---------------------------|
| `tox` | 2:53.37 | 59.92 |
| `tox -r` | 4:55.11 | 1:37.75 |

Note: `tox -p` runs 8 envs in parallel on my machine by default. This number and thus the timings may be different depending on the configuration of your machine.