### PR TITLE
optionally use select_related to pull related fields for `old`

### DIFF
--- a/auditlog/conf.py
+++ b/auditlog/conf.py
@@ -15,3 +15,8 @@ settings.AUDITLOG_EXCLUDE_TRACKING_MODELS = getattr(
 settings.AUDITLOG_INCLUDE_TRACKING_MODELS = getattr(
     settings, "AUDITLOG_INCLUDE_TRACKING_MODELS", ()
 )
+
+# Do select_related on related fields to eliminate unnecessary queries
+settings.AUDITLOG_SELECT_RELATED_FIELDS = getattr(
+    settings, "AUDITLOG_SELECT_RELATED_FIELDS", False
+)


### PR DESCRIPTION
Add the ability to use select_related to pull related fields when getting the old instance to compare against.  This should eliminate some unnecessary queries and boost performance, particularly when dealing with lots of related fields.