### PR TITLE
Handle port in `remote_addr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Fixes
 
 - fix: Display `created` timestamp in server timezone ([#404](https://github.com/jazzband/django-auditlog/pull/404))
+- fix: Handle port in `remote_addr` ([#417](https://github.com/jazzband/django-auditlog/pull/417))
 
 ## 2.1.1 (2022-07-27)
 

--- a/auditlog/middleware.py
+++ b/auditlog/middleware.py
@@ -12,13 +12,18 @@ class AuditlogMiddleware:
     def __init__(self, get_response=None):
         self.get_response = get_response
 
-    def __call__(self, request):
-
+    @staticmethod
+    def _get_remote_addr(request):
         if request.headers.get("X-Forwarded-For"):
             # In case of proxy, set 'original' address
             remote_addr = request.headers.get("X-Forwarded-For").split(",")[0]
+            # Remove port number from remote_addr
+            return remote_addr.split(":")[0]
         else:
-            remote_addr = request.META.get("REMOTE_ADDR")
+            return request.META.get("REMOTE_ADDR")
+
+    def __call__(self, request):
+        remote_addr = self._get_remote_addr(request)
 
         if hasattr(request, "user") and request.user.is_authenticated:
             context = set_actor(actor=request.user, remote_addr=remote_addr)

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -437,6 +437,19 @@ class MiddlewareTest(TestCase):
 
         self.assert_no_listeners()
 
+    def test_get_remote_addr(self):
+        tests = [  # (headers, expected_remote_addr)
+            ({}, "127.0.0.1"),
+            ({"HTTP_X_FORWARDED_FOR": "127.0.0.2"}, "127.0.0.2"),
+            ({"HTTP_X_FORWARDED_FOR": "127.0.0.3:1234"}, "127.0.0.3"),
+        ]
+        for headers, expected_remote_addr in tests:
+            with self.subTest(headers=headers):
+                request = self.factory.get("/", **headers)
+                self.assertEqual(
+                    self.middleware._get_remote_addr(request), expected_remote_addr
+                )
+
 
 class SimpleIncludeModelTest(TestCase):
     """Log only changes in include_fields"""


### PR DESCRIPTION
Fixes https://github.com/jazzband/django-auditlog/issues/414 and https://github.com/jazzband/django-auditlog/issues/238