### PR TITLE
Replace the `django.utils.timezone.utc` by `datetime.timezone.utc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat: New context manager `disable_auditlog` to turn off logging and a new setting `AUDITLOG_DISABLE_ON_RAW_SAVE`
   to disable it during raw-save operations like loaddata. [#446](https://github.com/jazzband/django-auditlog/pull/446)
 - Python: Confirm Python 3.11 support ([#447](https://github.com/jazzband/django-auditlog/pull/447))
+- feat: Replace the `django.utils.timezone.utc` by `datetime.timezone.utc`. [#448](https://github.com/jazzband/django-auditlog/pull/448)
 
 #### Fixes
 

--- a/auditlog/diff.py
+++ b/auditlog/diff.py
@@ -1,7 +1,9 @@
+from datetime import timezone
+
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import NOT_PROVIDED, DateTimeField, JSONField, Model
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 from django.utils.encoding import smart_str
 
 
@@ -63,8 +65,12 @@ def get_field_value(obj, field):
             # DateTimeFields are timezone-aware, so we need to convert the field
             # to its naive form before we can accurately compare them for changes.
             value = field.to_python(getattr(obj, field.name, None))
-            if value is not None and settings.USE_TZ and not timezone.is_naive(value):
-                value = timezone.make_naive(value, timezone=timezone.utc)
+            if (
+                value is not None
+                and settings.USE_TZ
+                and not django_timezone.is_naive(value)
+            ):
+                value = django_timezone.make_naive(value, timezone=timezone.utc)
         elif isinstance(field, JSONField):
             value = field.to_python(getattr(obj, field.name, None))
         else:

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -1,6 +1,7 @@
 import ast
 import json
 from copy import deepcopy
+from datetime import timezone
 from typing import Any, Dict, List
 
 from dateutil import parser
@@ -12,7 +13,7 @@ from django.core import serializers
 from django.core.exceptions import FieldDoesNotExist
 from django.db import DEFAULT_DB_ALIAS, models
 from django.db.models import Q, QuerySet
-from django.utils import formats, timezone
+from django.utils import formats
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext_lazy as _
 

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -634,7 +634,7 @@ class DateTimeFieldModelTest(TestCase):
         super().tearDown()
 
     def test_model_with_same_time(self):
-        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=datetime.timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -648,7 +648,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 1, msg="There is one log entry")
 
         # Change timestamp to same datetime and timezone
-        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=datetime.timezone.utc)
         dtm.timestamp = timestamp
         dtm.date = datetime.date(2017, 1, 10)
         dtm.time = datetime.time(12, 0)
@@ -658,7 +658,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 1, msg="There is one log entry")
 
     def test_model_with_different_timezone(self):
-        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=datetime.timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -680,7 +680,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 1, msg="There is one log entry")
 
     def test_model_with_different_datetime(self):
-        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=datetime.timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -694,7 +694,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 1, msg="There is one log entry")
 
         # Change timestamp to another datetime in the same timezone
-        timestamp = datetime.datetime(2017, 1, 10, 13, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 13, 0, tzinfo=datetime.timezone.utc)
         dtm.timestamp = timestamp
         dtm.save()
 
@@ -702,7 +702,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 2, msg="There are two log entries")
 
     def test_model_with_different_date(self):
-        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=datetime.timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -724,7 +724,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 2, msg="There are two log entries")
 
     def test_model_with_different_time(self):
-        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=datetime.timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -746,7 +746,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 2, msg="There are two log entries")
 
     def test_model_with_different_time_and_timezone(self):
-        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=datetime.timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -768,7 +768,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 2, msg="There are two log entries")
 
     def test_changes_display_dict_datetime(self):
-        timestamp = datetime.datetime(2017, 1, 10, 15, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 15, 0, tzinfo=datetime.timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -813,7 +813,7 @@ class DateTimeFieldModelTest(TestCase):
             )
 
     def test_changes_display_dict_date(self):
-        timestamp = datetime.datetime(2017, 1, 10, 15, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 15, 0, tzinfo=datetime.timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -856,7 +856,7 @@ class DateTimeFieldModelTest(TestCase):
             )
 
     def test_changes_display_dict_time(self):
-        timestamp = datetime.datetime(2017, 1, 10, 15, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 15, 0, tzinfo=datetime.timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -899,7 +899,7 @@ class DateTimeFieldModelTest(TestCase):
             )
 
     def test_update_naive_dt(self):
-        timestamp = datetime.datetime(2017, 1, 10, 15, 0, tzinfo=timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 15, 0, tzinfo=datetime.timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -912,7 +912,9 @@ class DateTimeFieldModelTest(TestCase):
         dtm.save()
 
         # Change with naive field doesnt raise error
-        dtm.naive_dt = timezone.make_naive(timezone.now(), timezone=timezone.utc)
+        dtm.naive_dt = timezone.make_naive(
+            timezone.now(), timezone=datetime.timezone.utc
+        )
         dtm.save()
 
 

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -650,7 +650,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 1, msg="There is one log entry")
 
         # Change timestamp to same datetime and timezone
-        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=datetime.timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)
         dtm.timestamp = timestamp
         dtm.date = datetime.date(2017, 1, 10)
         dtm.time = datetime.time(12, 0)
@@ -682,7 +682,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 1, msg="There is one log entry")
 
     def test_model_with_different_datetime(self):
-        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=datetime.timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(
@@ -748,7 +748,7 @@ class DateTimeFieldModelTest(TestCase):
         self.assertEqual(dtm.history.count(), 2, msg="There are two log entries")
 
     def test_model_with_different_time_and_timezone(self):
-        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=datetime.timezone.utc)
+        timestamp = datetime.datetime(2017, 1, 10, 12, 0, tzinfo=timezone.utc)
         date = datetime.date(2017, 1, 10)
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(


### PR DESCRIPTION
fixes https://github.com/jazzband/django-auditlog/issues/427