### PR TITLE
Make log entries read-only in the admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+#### Fixes
+- fix: Make log entries read-only in the admin. ([#449](https://github.com/jazzband/django-auditlog/pull/449))
+
 ## 2.2.0 (2022-10-07)
 
 #### Improvements

--- a/auditlog/admin.py
+++ b/auditlog/admin.py
@@ -26,5 +26,10 @@ class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
     ]
 
     def has_add_permission(self, request):
-        # As audit admin doesn't allow log creation from admin
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
         return False

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1292,7 +1292,7 @@ class AdminPanelTest(TestCase):
         res = self.client.get(f"/admin/auditlog/logentry/{log_pk}/", follow=True)
         self.assertEqual(res.status_code, 200)
         res = self.client.get(f"/admin/auditlog/logentry/{log_pk}/delete/")
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, 403)
         res = self.client.get(f"/admin/auditlog/logentry/{log_pk}/history/")
         self.assertEqual(res.status_code, 200)
 


### PR DESCRIPTION
This is a follow-up fix after a real-world staff user deleted a few auditlog entries through the admin by mistake.