### PR TITLE
fix changes_display_dict to display added/deleted objects for m2m updates

### DIFF
--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -464,6 +464,16 @@ class LogEntry(models.Model):
                 except AttributeError:
                     # if the field is a relationship it has no internal type and exclude it
                     continue
+                
+                if field_type == "ManyToManyField":
+                    values_display = values
+                    values_display['objects'] = [f"{i[:140]}..." if len(i) >140 else i for i in values['objects'] ]
+                    verbose_name = model_fields["mapping_fields"].get(
+                        field.name, getattr(field, "verbose_name", field.name)
+                    )
+                    changes_display_dict[verbose_name] = values_display
+                    continue
+
                 for value in values:
                     # handle case where field is a datetime, date, or time type
                     if field_type in ["DateTimeField", "DateField", "TimeField"]:


### PR DESCRIPTION
In one of my projects I needed to use the changes_display_dict function in a Django template to display changes of a m2m field.
Apparently for such field the `changes_display_dict` function is not storing the added/deleted object while the `changes_dict` function does. The changes_display_dict function just store a list like this: `['type', 'operation', 'objects']` .
See screenshots attached. 

![changes_dict](https://user-images.githubusercontent.com/6312038/204507664-681ac188-788a-4cc6-bd70-09c44df5348a.PNG)
![changes_display_dict](https://user-images.githubusercontent.com/6312038/204507691-d2edde7e-0bec-42cf-b4eb-f2dfe3aa15d9.PNG)

I slightly modified the `changes_display_dict` function to also store the list of added/removed objects. The result is the following:

![changes_display_dict_after](https://user-images.githubusercontent.com/6312038/204508245-0a5622e3-e639-4892-a2f3-5594892063dd.PNG)

I hope you could consider merging this if appropriate. Happy to implement any changes/improvements you might suggest on my current proposal.
