### PR TITLE
Fix LogEntry.changes_dict() to return {} when json.loads() returns None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Fixes
 
-- fix: Make sure `LogEntry.changes_dict()` return an empty dict instead of `None` when `json.loads()` returns `None`. ([#472](https://github.com/jazzband/django-auditlog/pull/472))
+- fix: Make sure `LogEntry.changes_dict()` returns an empty dict instead of `None` when `json.loads()` returns `None`. ([#472](https://github.com/jazzband/django-auditlog/pull/472))
 
 ## 2.2.1 (2022-11-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Release
 
+#### Fixes
+
+- fix: Make sure `LogEntry.changes_dict()` return an empty dict instead of `None` when `json.loads()` returns `None`. ([#472](https://github.com/jazzband/django-auditlog/pull/472))
+
 ## 2.2.1 (2022-11-28)
 
 #### Fixes

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -387,7 +387,7 @@ class LogEntry(models.Model):
         :return: The changes recorded in this log entry as a dictionary object.
         """
         try:
-            return json.loads(self.changes)
+            return json.loads(self.changes) or {}
         except ValueError:
             return {}
 

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1841,6 +1841,7 @@ class TestAccessLog(TestCase):
             log_entry.action, LogEntry.Action.ACCESS, msg="Action is 'ACCESS'"
         )
         self.assertEqual(log_entry.changes, "null")
+        self.assertEqual(log_entry.changes_dict, {})
 
 
 @override_settings(AUDITLOG_DISABLE_ON_RAW_SAVE=True)


### PR DESCRIPTION
`LogEntry.changes_str` raises an exception when viewing the new "accessed" AuditLog objects with no changes. This PR fixes `LogEntry.changes_dict()` so it always returns a dict, even if `json.loads() `returns `None`.

This PR fixes #471 which has the backtrace and more details :+1: 