### PR TITLE
Convert AUDITLOG_EXCLUDE_TRACKING_MODELS to tuple before concatenate

### DIFF
--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -247,7 +247,8 @@ class AuditlogModelRegistry:
     ) -> List[ModelBase]:
         exclude_models = [
             model
-            for app_model in tuple(exclude_tracking_models) + self.DEFAULT_EXCLUDE_MODELS
+            for app_model in tuple(exclude_tracking_models)
+            + self.DEFAULT_EXCLUDE_MODELS
             for model in self._get_model_classes(app_model)
         ]
         return exclude_models

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -247,7 +247,7 @@ class AuditlogModelRegistry:
     ) -> List[ModelBase]:
         exclude_models = [
             model
-            for app_model in exclude_tracking_models + self.DEFAULT_EXCLUDE_MODELS
+            for app_model in tuple(exclude_tracking_models) + self.DEFAULT_EXCLUDE_MODELS
             for model in self._get_model_classes(app_model)
         ]
         return exclude_models

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1168,7 +1168,17 @@ class RegisterModelSettingsTest(TestCase):
         AUDITLOG_INCLUDE_ALL_MODELS=True,
         AUDITLOG_EXCLUDE_TRACKING_MODELS=("auditlog_tests.SimpleExcludeModel",),
     )
-    def test_register_from_settings_register_all_models_with_exclude_models(self):
+    def test_register_from_settings_register_all_models_with_exclude_models_tuple(self):
+        self.test_auditlog.register_from_settings()
+
+        self.assertFalse(self.test_auditlog.contains(SimpleExcludeModel))
+        self.assertTrue(self.test_auditlog.contains(ChoicesFieldModel))
+
+    @override_settings(
+        AUDITLOG_INCLUDE_ALL_MODELS=True,
+        AUDITLOG_EXCLUDE_TRACKING_MODELS=["auditlog_tests.SimpleExcludeModel"],
+    )
+    def test_register_from_settings_register_all_models_with_exclude_models_list(self):
         self.test_auditlog.register_from_settings()
 
         self.assertFalse(self.test_auditlog.contains(SimpleExcludeModel))


### PR DESCRIPTION
Allow both list and tuple types for AUDITLOG_EXCLUDE_TRACKING_MODELS. Fixes #486