### PR TITLE
Revert #449 "Disallow changing or deleting log entries"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Release
 
+#### Fixes
+
+- fix: revert [#449](https://github.com/jazzband/django-auditlog/pull/449) "Make log entries read-only in the admin" as it breaks deletion of any auditlogged model through the admin when `AuditlogHistoryField` is used. ([#496](https://github.com/jazzband/django-auditlog/pull/496))
+
 ## 2.2.1 (2022-11-28)
 
 #### Fixes

--- a/auditlog/admin.py
+++ b/auditlog/admin.py
@@ -26,10 +26,5 @@ class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
     ]
 
     def has_add_permission(self, request):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
+        # As audit admin doesn't allow log creation from admin
         return False

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1297,7 +1297,7 @@ class AdminPanelTest(TestCase):
         res = self.client.get(f"/admin/auditlog/logentry/{log_pk}/", follow=True)
         self.assertEqual(res.status_code, 200)
         res = self.client.get(f"/admin/auditlog/logentry/{log_pk}/delete/")
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, 200)
         res = self.client.get(f"/admin/auditlog/logentry/{log_pk}/history/")
         self.assertEqual(res.status_code, 200)
 


### PR DESCRIPTION
As described in #493, this change inadvertently breaks deletion of auditlogged objects.