### PR TITLE
Add ability to globally exclude fields by name on all models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - feat: Added support for Correlation ID. ([#481](https://github.com/jazzband/django-auditlog/pull/481))
 - feat: Added pre-log and post-log signals. ([#483](https://github.com/jazzband/django-auditlog/pull/483))
 - feat: Make timestamp in LogEntry overwritable. ([#476](https://github.com/jazzband/django-auditlog/pull/476))
+- feat: Support excluding field names globally when ```AUDITLOG_INCLUDE_ALL_MODELS``` is enabled. ([#498](https://github.com/jazzband/django-auditlog/pull/498))
 
 #### Fixes
 

--- a/auditlog/conf.py
+++ b/auditlog/conf.py
@@ -16,6 +16,11 @@ settings.AUDITLOG_INCLUDE_TRACKING_MODELS = getattr(
     settings, "AUDITLOG_INCLUDE_TRACKING_MODELS", ()
 )
 
+# Exclude named fields across all models
+settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS = getattr(
+    settings, "AUDITLOG_EXCLUDE_TRACKING_FIELDS", ()
+)
+
 # Disable on raw save to avoid logging imports and similar
 settings.AUDITLOG_DISABLE_ON_RAW_SAVE = getattr(
     settings, "AUDITLOG_DISABLE_ON_RAW_SAVE", False

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -301,12 +301,18 @@ class AuditlogModelRegistry:
             and not settings.AUDITLOG_INCLUDE_ALL_MODELS
         ):
             raise ValueError(
-                "In order to use 'AUDITLOG_EXCLUDE_TRACKING_FIELDS', setting 'AUDITLOG_INCLUDE_ALL_MODELS' must be set to 'True'"
+                "In order to use 'AUDITLOG_EXCLUDE_TRACKING_FIELDS', "
+                "setting 'AUDITLOG_INCLUDE_ALL_MODELS' must be set to 'True'"
             )
 
         if not isinstance(settings.AUDITLOG_INCLUDE_TRACKING_MODELS, (list, tuple)):
             raise TypeError(
                 "Setting 'AUDITLOG_INCLUDE_TRACKING_MODELS' must be a list or tuple"
+            )
+
+        if not isinstance(settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS, (list, tuple)):
+            raise TypeError(
+                "Setting 'AUDITLOG_EXCLUDE_TRACKING_FIELDS' must be a list or tuple"
             )
 
         for item in settings.AUDITLOG_INCLUDE_TRACKING_MODELS:

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -296,6 +296,16 @@ class AuditlogModelRegistry:
                 "setting 'AUDITLOG_INCLUDE_ALL_MODELS' must set to 'True'"
             )
 
+        if isinstance(settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS, (list, tuple)) and not settings.AUDITLOG_INCLUDE_ALL_MODELS:
+            raise  ValueError(
+                "In order to use AUDITLOG_EXCLUDE_TRACKING_FIELDS, setting AUDITLOG_INCLUDE_ALL_MODELS must be set to 'True'"
+            )
+
+        if not isinstance(settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS, (list, tuple)):
+            raise TypeError(
+                "AUDITLOG_EXCLUDE_TRACKING_FIELDS must be a list or tuple"
+            )
+
         if not isinstance(settings.AUDITLOG_INCLUDE_TRACKING_MODELS, (list, tuple)):
             raise TypeError(
                 "Setting 'AUDITLOG_INCLUDE_TRACKING_MODELS' must be a list or tuple"

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -304,8 +304,11 @@ class AuditlogModelRegistry:
                 "In order to use AUDITLOG_EXCLUDE_TRACKING_FIELDS, setting AUDITLOG_INCLUDE_ALL_MODELS must be set to 'True'"
             )
 
-        if settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS and not settings.AUDITLOG_INCLUDE_ALL_MODELS:
-            raise  ValueError(
+        if (
+            settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS
+            and not settings.AUDITLOG_INCLUDE_ALL_MODELS
+        ):
+            raise ValueError(
                 "In order to use 'AUDITLOG_EXCLUDE_TRACKING_FIELDS', setting 'AUDITLOG_INCLUDE_ALL_MODELS' must be set to 'True'"
             )
 

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -297,14 +297,6 @@ class AuditlogModelRegistry:
             )
 
         if (
-            isinstance(settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS, (list, tuple))
-            and not settings.AUDITLOG_INCLUDE_ALL_MODELS
-        ):
-            raise ValueError(
-                "In order to use AUDITLOG_EXCLUDE_TRACKING_FIELDS, setting AUDITLOG_INCLUDE_ALL_MODELS must be set to 'True'"
-            )
-
-        if (
             settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS
             and not settings.AUDITLOG_INCLUDE_ALL_MODELS
         ):

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -113,6 +113,9 @@ class AuditlogModelRegistry:
                 "set. Did you forget to set serialized_data to True?"
             )
 
+        for fld in settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS:
+            exclude_fields.append(fld)
+
         def registrar(cls):
             """Register models for a given class."""
             if not issubclass(cls, Model):

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -296,15 +296,16 @@ class AuditlogModelRegistry:
                 "setting 'AUDITLOG_INCLUDE_ALL_MODELS' must set to 'True'"
             )
 
-        if isinstance(settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS, (list, tuple)) and not settings.AUDITLOG_INCLUDE_ALL_MODELS:
-            raise  ValueError(
+        if (
+            isinstance(settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS, (list, tuple))
+            and not settings.AUDITLOG_INCLUDE_ALL_MODELS
+        ):
+            raise ValueError(
                 "In order to use AUDITLOG_EXCLUDE_TRACKING_FIELDS, setting AUDITLOG_INCLUDE_ALL_MODELS must be set to 'True'"
             )
 
         if not isinstance(settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS, (list, tuple)):
-            raise TypeError(
-                "AUDITLOG_EXCLUDE_TRACKING_FIELDS must be a list or tuple"
-            )
+            raise TypeError("AUDITLOG_EXCLUDE_TRACKING_FIELDS must be a list or tuple")
 
         if not isinstance(settings.AUDITLOG_INCLUDE_TRACKING_MODELS, (list, tuple)):
             raise TypeError(

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -304,8 +304,10 @@ class AuditlogModelRegistry:
                 "In order to use AUDITLOG_EXCLUDE_TRACKING_FIELDS, setting AUDITLOG_INCLUDE_ALL_MODELS must be set to 'True'"
             )
 
-        if not isinstance(settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS, (list, tuple)):
-            raise TypeError("AUDITLOG_EXCLUDE_TRACKING_FIELDS must be a list or tuple")
+        if settings.AUDITLOG_EXCLUDE_TRACKING_FIELDS and not settings.AUDITLOG_INCLUDE_ALL_MODELS:
+            raise  ValueError(
+                "In order to use 'AUDITLOG_EXCLUDE_TRACKING_FIELDS', setting 'AUDITLOG_INCLUDE_ALL_MODELS' must be set to 'True'"
+            )
 
         if not isinstance(settings.AUDITLOG_INCLUDE_TRACKING_MODELS, (list, tuple)):
             raise TypeError(

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1166,11 +1166,13 @@ class RegisterModelSettingsTest(TestCase):
             ):
                 self.test_auditlog.register_from_settings()
 
-        with override_settings(AUDITLOG_EXCLUDE_TRACKING_FIELDS=('created', 'modified')):
+        with override_settings(
+            AUDITLOG_EXCLUDE_TRACKING_FIELDS=("created", "modified")
+        ):
             with self.assertRaisesMessage(
                 ValueError,
                 "In order to use 'AUDITLOG_EXCLUDE_TRACKING_FIELDS', "
-                "setting 'AUDITLOG_INCLUDE_ALL_MODELS' must be set to 'True'"
+                "setting 'AUDITLOG_INCLUDE_ALL_MODELS' must be set to 'True'",
             ):
                 self.test_auditlog.register_from_settings()
 

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1159,7 +1159,10 @@ class RegisterModelSettingsTest(TestCase):
             ):
                 self.test_auditlog.register_from_settings()
 
-        with override_settings(AUDITLOG_INCLUDE_ALL_MODELS=True, AUDITLOG_EXCLUDE_TRACKING_FIELDS="badvalue"):
+        with override_settings(
+            AUDITLOG_INCLUDE_ALL_MODELS=True,
+            AUDITLOG_EXCLUDE_TRACKING_FIELDS="badvalue",
+        ):
             with self.assertRaisesMessage(
                 TypeError,
                 "Setting 'AUDITLOG_EXCLUDE_TRACKING_FIELDS' must be a list or tuple",
@@ -1239,11 +1242,19 @@ class RegisterModelSettingsTest(TestCase):
         AUDITLOG_INCLUDE_ALL_MODELS=True,
         AUDITLOG_EXCLUDE_TRACKING_FIELDS=("datetime",),
     )
-    def test_register_from_settings_register_all_models_with_exclude_tracking_fields(self):
+    def test_register_from_settings_register_all_models_with_exclude_tracking_fields(
+        self,
+    ):
         self.test_auditlog.register_from_settings()
 
-        self.assertEqual(self.test_auditlog.get_model_fields(SimpleModel)['exclude_fields'], ['datetime'])
-        self.assertEqual(self.test_auditlog.get_model_fields(AltPrimaryKeyModel)['exclude_fields'], ['datetime'])
+        self.assertEqual(
+            self.test_auditlog.get_model_fields(SimpleModel)["exclude_fields"],
+            ["datetime"],
+        )
+        self.assertEqual(
+            self.test_auditlog.get_model_fields(AltPrimaryKeyModel)["exclude_fields"],
+            ["datetime"],
+        )
 
     @override_settings(
         AUDITLOG_INCLUDE_ALL_MODELS=True,

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1159,6 +1159,21 @@ class RegisterModelSettingsTest(TestCase):
             ):
                 self.test_auditlog.register_from_settings()
 
+        with override_settings(AUDITLOG_EXCLUDE_TRACKING_FIELDS="badvalue"):
+            with self.assertRaisesMessage(
+                TypeError,
+                "AUDITLOG_EXCLUDE_TRACKING_FIELDS must be a list or tuple",
+            ):
+                self.test_auditlog.register_from_settings()
+
+        with override_settings(AUDITLOG_EXCLUDE_TRACKING_FIELDS=('created', 'modified')):
+            with self.assertRaisesMessage(
+                ValueError,
+                "In order to use 'AUDITLOG_EXCLUDE_TRACKING_FIELDS', "
+                "setting 'AUDITLOG_INCLUDE_ALL_MODELS' must be set to 'True'"
+            ):
+                self.test_auditlog.register_from_settings()
+
         with override_settings(AUDITLOG_INCLUDE_TRACKING_MODELS="str"):
             with self.assertRaisesMessage(
                 TypeError,

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1159,10 +1159,10 @@ class RegisterModelSettingsTest(TestCase):
             ):
                 self.test_auditlog.register_from_settings()
 
-        with override_settings(AUDITLOG_EXCLUDE_TRACKING_FIELDS="badvalue"):
+        with override_settings(AUDITLOG_INCLUDE_ALL_MODELS=True, AUDITLOG_EXCLUDE_TRACKING_FIELDS="badvalue"):
             with self.assertRaisesMessage(
                 TypeError,
-                "AUDITLOG_EXCLUDE_TRACKING_FIELDS must be a list or tuple",
+                "Setting 'AUDITLOG_EXCLUDE_TRACKING_FIELDS' must be a list or tuple",
             ):
                 self.test_auditlog.register_from_settings()
 
@@ -1234,6 +1234,16 @@ class RegisterModelSettingsTest(TestCase):
 
         self.assertFalse(self.test_auditlog.contains(SimpleExcludeModel))
         self.assertTrue(self.test_auditlog.contains(ChoicesFieldModel))
+
+    @override_settings(
+        AUDITLOG_INCLUDE_ALL_MODELS=True,
+        AUDITLOG_EXCLUDE_TRACKING_FIELDS=("datetime",),
+    )
+    def test_register_from_settings_register_all_models_with_exclude_tracking_fields(self):
+        self.test_auditlog.register_from_settings()
+
+        self.assertEqual(self.test_auditlog.get_model_fields(SimpleModel)['exclude_fields'], ['datetime'])
+        self.assertEqual(self.test_auditlog.get_model_fields(AltPrimaryKeyModel)['exclude_fields'], ['datetime'])
 
     @override_settings(
         AUDITLOG_INCLUDE_ALL_MODELS=True,

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -189,6 +189,23 @@ You can use this setting to register all your models:
 
 .. versionadded:: 2.1.0
 
+**AUDITLOG_EXCLUDE_TRACKING_FIELDS**
+
+You can use this setting to exclude named fields from ALL models.
+This is useful when lots of models share similar fields like
+```created``` and ```modified``` and you want those excluded from
+logging.
+It will be considered when ``AUDITLOG_INCLUDE_ALL_MODELS`` is `True`.
+
+.. code-block:: python
+
+    AUDITLOG_EXCLUDE_TRACKING_FIELDS = (
+        "created",
+        "modified"
+    )
+
+.. versionadded:: 2.2.3
+
 **AUDITLOG_EXCLUDE_TRACKING_MODELS**
 
 You can use this setting to exclude models in registration process.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -204,7 +204,7 @@ It will be considered when ``AUDITLOG_INCLUDE_ALL_MODELS`` is `True`.
         "modified"
     )
 
-.. versionadded:: 2.2.3
+.. versionadded:: 3.0.0
 
 **AUDITLOG_EXCLUDE_TRACKING_MODELS**
 


### PR DESCRIPTION
My first stab at solving #467.

Adds the ability to list field names in ```AUDITLOG_EXCLUDE_TRACKING_MODELS``` that will be excluded from logging.
If a field in ```AUDITLOG_EXCLUDE_TRACKING_MODELS``` is the only field changed, nothing will be logged.