### PR TITLE
Run django main tests on Python >= 3.10

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     {py37,py38,py39,py310}-django32
     {py38,py39,py310}-django40
-    {py38,py39,py310,py311}-django{41,main}
+    {py38,py39,py310,py311}-django41
+    {py310,py311}-djangomain
     py37-docs
     py38-lint
 


### PR DESCRIPTION
Django main branch is going to be prepared for version 5.0.
As [Django 5.0 requires Python >= 3.10](https://docs.djangoproject.com/en/dev/faq/install/#what-are-django-s-prerequisites), [the CI fails on django main and Python < 3.10](https://github.com/jazzband/django-auditlog/actions/runs/3952856514/jobs/6775443889)