### PR TITLE
fixed getting field's verbose_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fix: Fix a bug in audit log admin page when `USE_TZ=False`. ([#511](https://github.com/jazzband/django-auditlog/pull/511))
 - fix: Make sure `LogEntry.changes_dict()` returns an empty dict instead of `None` when `json.loads()` returns `None`. ([#472](https://github.com/jazzband/django-auditlog/pull/472))
 - fix: Always set remote_addr even if the request has no authenticated user. ([#484](https://github.com/jazzband/django-auditlog/pull/484))
+- fix: Fix a bug in getting field's `verbose_name` when model is not accessible. ([508](https://github.com/jazzband/django-auditlog/pull/508))
 
 ## 2.2.2 (2023-01-16)
 

--- a/auditlog/mixins.py
+++ b/auditlog/mixins.py
@@ -139,7 +139,7 @@ class LogEntryAdminMixin:
 
     def field_verbose_name(self, obj, field_name: str):
         model = obj.content_type.model_class()
-        if not model:
+        if model is None:
             return field_name
         try:
             model_fields = auditlog.get_model_fields(model._meta.model)

--- a/auditlog/mixins.py
+++ b/auditlog/mixins.py
@@ -139,6 +139,8 @@ class LogEntryAdminMixin:
 
     def field_verbose_name(self, obj, field_name: str):
         model = obj.content_type.model_class()
+        if not model:
+            return field_name
         try:
             model_fields = auditlog.get_model_fields(model._meta.model)
             mapping_field_name = model_fields["mapping_fields"].get(field_name)

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1651,6 +1651,22 @@ class DiffMsgTest(TestCase):
         # Re-register
         auditlog.register(SimpleModel)
 
+    def test_field_verbose_name(self):
+        log_entry = self._create_log_entry(
+            LogEntry.Action.CREATE,
+            {"test": "test"},
+        )
+
+        self.assertEqual(
+            self.admin.field_verbose_name(log_entry, "actor"),
+            "Actor"
+        )
+        with patch("django.contrib.contenttypes.models.ContentType.model_class", return_value=None):
+            self.assertEqual(
+                self.admin.field_verbose_name(log_entry, "actor"),
+                "actor"
+            )
+
 
 class NoDeleteHistoryTest(TestCase):
     def test_delete_related(self):

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1657,15 +1657,12 @@ class DiffMsgTest(TestCase):
             {"test": "test"},
         )
 
-        self.assertEqual(
-            self.admin.field_verbose_name(log_entry, "actor"),
-            "Actor"
-        )
-        with patch("django.contrib.contenttypes.models.ContentType.model_class", return_value=None):
-            self.assertEqual(
-                self.admin.field_verbose_name(log_entry, "actor"),
-                "actor"
-            )
+        self.assertEqual(self.admin.field_verbose_name(log_entry, "actor"), "Actor")
+        with patch(
+            "django.contrib.contenttypes.models.ContentType.model_class",
+            return_value=None,
+        ):
+            self.assertEqual(self.admin.field_verbose_name(log_entry, "actor"), "actor")
 
 
 class NoDeleteHistoryTest(TestCase):


### PR DESCRIPTION
Sometimes, for example, when using a custom db router in microservices, there may not be direct access to the application / model. In such cases, we need te get at least field name.