### PR TITLE
Fix a bug in audit log admin page when `USE_TZ=False`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 #### Fixes
 
+- fix: Fix a bug in audit log admin page when `USE_TZ=False`. ([#511](https://github.com/jazzband/django-auditlog/pull/511))
 - fix: Make sure `LogEntry.changes_dict()` returns an empty dict instead of `None` when `json.loads()` returns `None`. ([#472](https://github.com/jazzband/django-auditlog/pull/472))
 - fix: Always set remote_addr even if the request has no authenticated user. ([#484](https://github.com/jazzband/django-auditlog/pull/484))
 

--- a/auditlog/mixins.py
+++ b/auditlog/mixins.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest
 from django.urls.exceptions import NoReverseMatch
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
-from django.utils.timezone import localtime
+from django.utils.timezone import is_aware, localtime
 from django.utils.translation import gettext_lazy as _
 
 from auditlog.models import LogEntry
@@ -23,7 +23,9 @@ class LogEntryAdminMixin:
 
     @admin.display(description=_("Created"))
     def created(self, obj):
-        return localtime(obj.timestamp)
+        if is_aware(obj.timestamp):
+            return localtime(obj.timestamp)
+        return obj.timestamp
 
     @admin.display(description=_("User"))
     def user_url(self, obj):

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1461,6 +1461,17 @@ class AdminPanelTest(TestCase):
                 created = self.admin.created(log_entry)
                 self.assertEqual(created.strftime("%Y-%m-%d %H:%M:%S"), timestamp)
 
+    @freezegun.freeze_time("2022-08-01 12:00:00Z")
+    def test_created_naive_datetime(self):
+        with self.settings(USE_TZ=False):
+            obj = SimpleModel.objects.create(text="For USE_TZ=False test")
+            log_entry = obj.history.latest()
+            created = self.admin.created(log_entry)
+            self.assertEqual(
+                created.strftime("%Y-%m-%d %H:%M:%S"),
+                "2022-08-01 12:00:00",
+            )
+
     def test_cid(self):
         self.client.force_login(self.user)
         expected_response = (


### PR DESCRIPTION
Continue to https://github.com/jazzband/django-auditlog/pull/487

Thanks @nbensa for providing the test case