### PR TITLE
Remove first_name / last_name from admin if missing from model

### DIFF
--- a/auditlog/admin.py
+++ b/auditlog/admin.py
@@ -31,7 +31,11 @@ class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
         "object_repr",
         "changes",
         f"actor__{user_model.USERNAME_FIELD}",
-    ] + (["actor__first_name", "actor__last_name"] if has_first_and_last_name_fields else [])
+    ] + (
+        ["actor__first_name", "actor__last_name"]
+        if has_first_and_last_name_fields
+        else []
+    )
     list_filter = ["action", ResourceTypeFilter, CIDFilter]
     readonly_fields = ["created", "resource_url", "action", "user_url", "msg"]
     fieldsets = [

--- a/auditlog/admin.py
+++ b/auditlog/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
 
-from auditlog.filters import ResourceTypeFilter
+from auditlog.filters import CIDFilter, ResourceTypeFilter
 from auditlog.mixins import LogEntryAdminMixin
 from auditlog.models import LogEntry
 
@@ -17,24 +18,36 @@ has_first_and_last_name_fields = (
 @admin.register(LogEntry)
 class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
     list_select_related = ["content_type", "actor"]
-    list_display = ["created", "resource_url", "action", "msg_short", "user_url"]
+    list_display = [
+        "created",
+        "resource_url",
+        "action",
+        "msg_short",
+        "user_url",
+        "cid_url",
+    ]
     search_fields = [
         "timestamp",
         "object_repr",
         "changes",
         f"actor__{user_model.USERNAME_FIELD}",
-    ] + (
-        ["actor__first_name", "actor__last_name"]
-        if has_first_and_last_name_fields
-        else []
-    )
-    list_filter = ["action", ResourceTypeFilter]
+    ] + (["actor__first_name", "actor__last_name"] if has_first_and_last_name_fields else [])
+    list_filter = ["action", ResourceTypeFilter, CIDFilter]
     readonly_fields = ["created", "resource_url", "action", "user_url", "msg"]
     fieldsets = [
-        (None, {"fields": ["created", "user_url", "resource_url"]}),
-        ("Changes", {"fields": ["action", "msg"]}),
+        (None, {"fields": ["created", "user_url", "resource_url", "cid"]}),
+        (_("Changes"), {"fields": ["action", "msg"]}),
     ]
 
     def has_add_permission(self, request):
-        # As audit admin doesn't allow log creation from admin
         return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def get_queryset(self, request):
+        self.request = request
+        return super().get_queryset(request=request)

--- a/auditlog/admin.py
+++ b/auditlog/admin.py
@@ -1,47 +1,40 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
-from django.utils.translation import gettext_lazy as _
 
-from auditlog.filters import CIDFilter, ResourceTypeFilter
+from auditlog.filters import ResourceTypeFilter
 from auditlog.mixins import LogEntryAdminMixin
 from auditlog.models import LogEntry
+
+user_model = get_user_model()
+
+user_model_fields = [field.name for field in user_model._meta.get_fields()]
+
+has_first_and_last_name_fields = (
+    "first_name" in user_model_fields and "last_name" in user_model_fields
+)
 
 
 @admin.register(LogEntry)
 class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
     list_select_related = ["content_type", "actor"]
-    list_display = [
-        "created",
-        "resource_url",
-        "action",
-        "msg_short",
-        "user_url",
-        "cid_url",
-    ]
+    list_display = ["created", "resource_url", "action", "msg_short", "user_url"]
     search_fields = [
         "timestamp",
         "object_repr",
         "changes",
-        "actor__first_name",
-        "actor__last_name",
-        f"actor__{get_user_model().USERNAME_FIELD}",
-    ]
-    list_filter = ["action", ResourceTypeFilter, CIDFilter]
+        f"actor__{user_model.USERNAME_FIELD}",
+    ] + (
+        ["actor__first_name", "actor__last_name"]
+        if has_first_and_last_name_fields
+        else []
+    )
+    list_filter = ["action", ResourceTypeFilter]
     readonly_fields = ["created", "resource_url", "action", "user_url", "msg"]
     fieldsets = [
-        (None, {"fields": ["created", "user_url", "resource_url", "cid"]}),
-        (_("Changes"), {"fields": ["action", "msg"]}),
+        (None, {"fields": ["created", "user_url", "resource_url"]}),
+        ("Changes", {"fields": ["action", "msg"]}),
     ]
 
     def has_add_permission(self, request):
+        # As audit admin doesn't allow log creation from admin
         return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
-    def get_queryset(self, request):
-        self.request = request
-        return super().get_queryset(request=request)


### PR DESCRIPTION
Closes #509 

This is a "static" approach, which I think is better than overriding `get_search_fields`. I believe the `get_*` methods are for truly dynamic behavior (based on the request, the current user, etc). With this, admin checks will still apply (though not particularly useful).