### PR TITLE
Audit changes to FK fields when saved using *_id naming.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 #### Fixes
 
+- fix: Audit changes to FK fields when saved using `*_id` naming. ([#525](https://github.com/jazzband/django-auditlog/pull/525))
 - fix: Fix a bug in audit log admin page when `USE_TZ=False`. ([#511](https://github.com/jazzband/django-auditlog/pull/511))
 - fix: Make sure `LogEntry.changes_dict()` returns an empty dict instead of `None` when `json.loads()` returns `None`. ([#472](https://github.com/jazzband/django-auditlog/pull/472))
 - fix: Always set remote_addr even if the request has no authenticated user. ([#484](https://github.com/jazzband/django-auditlog/pull/484))

--- a/auditlog/diff.py
+++ b/auditlog/diff.py
@@ -147,14 +147,14 @@ def model_instance_diff(
         model_fields = None
 
     if fields_to_check:
-        _fields = set()
-        for field in fields:
-            if isinstance(field, ForeignKey):
-                if field.attname in fields_to_check:
-                    _fields.add(field)
-            if field.name in fields_to_check:
-                _fields.add(field)
-        fields = _fields
+        fields = {
+            field
+            for field in fields
+            if (
+                (isinstance(field, ForeignKey) and field.attname in fields_to_check)
+                or (field.name in fields_to_check)
+            )
+        }
 
     # Check if fields must be filtered
     if (

--- a/auditlog/diff.py
+++ b/auditlog/diff.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import NOT_PROVIDED, DateTimeField, JSONField, Model
+from django.db.models import NOT_PROVIDED, DateTimeField, ForeignKey, JSONField, Model
 from django.utils import timezone as django_timezone
 from django.utils.encoding import smart_str
 
@@ -147,7 +147,14 @@ def model_instance_diff(
         model_fields = None
 
     if fields_to_check:
-        fields = {field for field in fields if field.name in fields_to_check}
+        _fields = set()
+        for field in fields:
+            if isinstance(field, ForeignKey):
+                if field.attname in fields_to_check:
+                    _fields.add(field)
+            if field.name in fields_to_check:
+                _fields.add(field)
+        fields = _fields
 
     # Check if fields must be filtered
     if (


### PR DESCRIPTION
In Django you can save changes to a FK field on a model using the ID field name (attname) in addition to the regular FK field name with:

    model.related_model_id = 42
    model.save(update_fields=["related_model_id'])

or:

    model.related_model = related_model
    model.save(update_fields=["related_model_id'])

as opposed to the more common:

    model.related_model = related_model
    model.save(update_fields=["related_model'])

This change ensures those model changes are logged properly.