### PR TITLE
Fix unnecessary log when adding already existed m2m record

### DIFF
--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -110,7 +110,7 @@ class LogEntryManager(models.Manager):
         from auditlog.cid import get_cid
 
         pk = self._get_pk_value(instance)
-        if changed_queryset is not None:
+        if changed_queryset:
             kwargs.setdefault(
                 "content_type", ContentType.objects.get_for_model(instance)
             )

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -415,6 +415,24 @@ class ManyRelatedModelTest(TestCase):
             },
         )
 
+    def test_adding_existing_related_obj(self):
+        self.obj.related.add(self.related)
+        log_entry = self.obj.history.first()
+        self.assertEqual(
+            log_entry.changes,
+            {
+                "related": {
+                    "type": "m2m",
+                    "operation": "add",
+                    "objects": [smart_str(self.related)],
+                }
+            },
+        )
+        # Add same related obj again.
+        self.obj.related.add(self.related)
+        latest_log_entry = self.obj.history.first()
+        self.assertEqual(log_entry.id, latest_log_entry.id)
+
 
 class MiddlewareTest(TestCase):
     """


### PR DESCRIPTION
In [log_m2m_changes](https://github.com/jazzband/django-auditlog/blob/45591463e8192b4ac0095e259cc4dcea0ac2fd6c/auditlog/models.py#L113) we are checking the queryset emptiness with `is not None` however this will always evaluate to True. So when we are adding same related m2m object there will be an unnecessary log with empty objects. This PR aim is to fix that so we don't get unnecessary logs.