### PR TITLE
Improve auto model registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - feat: Added pre-log and post-log signals. ([#483](https://github.com/jazzband/django-auditlog/pull/483))
 - feat: Make timestamp in LogEntry overwritable. ([#476](https://github.com/jazzband/django-auditlog/pull/476))
 - feat: Support excluding field names globally when ```AUDITLOG_INCLUDE_ALL_MODELS``` is enabled. ([#498](https://github.com/jazzband/django-auditlog/pull/498))
+- feat: Improved auto model registration to include auto-created models and exclude non-managed models, and automatically register m2m fields for models. ([#550](https://github.com/jazzband/django-auditlog/pull/550))
 
 #### Fixes
 

--- a/auditlog_tests/models.py
+++ b/auditlog_tests/models.py
@@ -304,6 +304,29 @@ class SerializeNaturalKeyRelatedModel(models.Model):
     history = AuditlogHistoryField(delete_related=False)
 
 
+class SimpleNonManagedModel(models.Model):
+    """
+    A simple model with no special things going on.
+    """
+
+    text = models.TextField(blank=True)
+    boolean = models.BooleanField(default=False)
+    integer = models.IntegerField(blank=True, null=True)
+    datetime = models.DateTimeField(auto_now=True)
+
+    history = AuditlogHistoryField()
+
+    def __str__(self):
+        return self.text
+
+    class Meta:
+        managed = False
+
+
+class AutoManyRelatedModel(models.Model):
+    related = models.ManyToManyField(SimpleModel)
+
+
 auditlog.register(AltPrimaryKeyModel)
 auditlog.register(UUIDPrimaryKeyModel)
 auditlog.register(ProxyModel)


### PR DESCRIPTION
closes #315
closes #548 

feat: collect all models including auto created ones and excluding non-managed ones
feat: automatically register m2m fields for models when opting to auto register models