### PR TITLE
Pass instance_old to post_log.send

### DIFF
--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -123,6 +123,7 @@ def _create_log_entry(
         post_log.send(
             sender,
             instance=instance,
+            instance_old=diff_old,
             action=action,
             error=error,
             pre_log_results=pre_log_results,


### PR DESCRIPTION
We need to send audit log to logstash (this can apply to any external database/API), so we need the old model object to extract the changes.