### PR TITLE
Stop deleting log entries in log_create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Breaking Changes
 
+- feat: stop deleting old log entries when a model with the same pk is created (i.e. the pk value is reused) ([#559](https://github.com/jazzband/django-auditlog/pull/559))
+
 #### Improvements
 
 #### Fixes

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -66,26 +66,6 @@ class LogEntryManager(models.Manager):
             if callable(get_additional_data):
                 kwargs.setdefault("additional_data", get_additional_data())
 
-            # Delete log entries with the same pk as a newly created model.
-            # This should only be necessary when a pk is used twice.
-            if kwargs.get("action", None) is LogEntry.Action.CREATE:
-                if (
-                    kwargs.get("object_id", None) is not None
-                    and self.filter(
-                        content_type=kwargs.get("content_type"),
-                        object_id=kwargs.get("object_id"),
-                    ).exists()
-                ):
-                    self.filter(
-                        content_type=kwargs.get("content_type"),
-                        object_id=kwargs.get("object_id"),
-                    ).delete()
-                else:
-                    self.filter(
-                        content_type=kwargs.get("content_type"),
-                        object_pk=kwargs.get("object_pk", ""),
-                    ).delete()
-
             # set correlation id
             kwargs.setdefault("cid", get_cid())
             return self.create(**kwargs)

--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -49,7 +49,7 @@ def log_update(sender, instance, **kwargs):
 
     Direct use is discouraged, connect your model through :py:func:`auditlog.registry.register` instead.
     """
-    if instance.pk is not None:
+    if not instance._state.adding:
         update_fields = kwargs.get("update_fields", None)
         old = sender.objects.filter(pk=instance.pk).first()
         _create_log_entry(


### PR DESCRIPTION
This pull request addresses two issues:
1. Even if a pk value is reused, we should not delete log entries for old deleted object. Old object's lifetime is easily identifiable by a pair of matching created & deleted log entries.
2. (why I started to look into this in the first place) `log_create` spends 22% of its run time calling `delete()` method in a test run of a medium-sized data loading job on my machine (7% of the total run time of the job).

I assume this is technically a breaking change so I'd like it included in 3.0.0 release too.

Notice the change in the `log_update` handler. Before my changes, every object creation was producing two log entries: `updated` log entry, then `created` log entry; and while creating this second log entry, auditlog was deleting the first one, so it was not noticeable.