### PR TITLE
fix: don't set the correlation_id if the `AUDITLOG_CID_GETTER` is `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 #### Improvements
 
 #### Fixes
-* fix: only fire the `post_log` signal when the log is created or when there is an error in the process.
+* fix: only fire the `post_log` signal when the log is created or when there is an error in the process ([#561](https://github.com/jazzband/django-auditlog/pull/561))
+* fix: don't set the correlation_id if the `AUDITLOG_CID_GETTER` is `None` ([#565](https://github.com/jazzband/django-auditlog/pull/565))
 
 ## 3.0.0-beta.1
 

--- a/auditlog/cid.py
+++ b/auditlog/cid.py
@@ -13,11 +13,16 @@ def set_cid(request: Optional[HttpRequest] = None) -> None:
     A function to read the cid from a request.
     If the header is not in the request, then we set it to `None`.
 
-    Note: we look for the header in `request.headers` and `request.META`.
+    Note: we look for the value of `AUDITLOG_CID_HEADER` in `request.headers` and in `request.META`.
+
+    This function doesn't do anything if the user is supplying their own `AUDITLOG_CID_GETTER`.
 
     :param request: The request to get the cid from.
     :return: None
     """
+    if settings.AUDITLOG_CID_GETTER:
+        return
+
     cid = None
     header = settings.AUDITLOG_CID_HEADER
 


### PR DESCRIPTION
It doesn't make sense to set it if we're not going to use it again.