### PR TITLE
fix: change verbose_name in changes_text migration

### DIFF
--- a/auditlog/migrations/0015_alter_logentry_changes.py
+++ b/auditlog/migrations/0015_alter_logentry_changes.py
@@ -24,7 +24,7 @@ def two_step_migrations() -> List:
         migrations.AddField(
             model_name="logentry",
             name="changes_text",
-            field=models.TextField(blank=True, verbose_name="text change message"),
+            field=models.TextField(blank=True, verbose_name="change message"),
         ),
         migrations.AlterField(
             model_name="logentry",


### PR DESCRIPTION
closes #570 
my bad.
I don't know how this happened. The good thing is that verbose_name doesn't alter the db, so we don't need to create a migration for people already on v3.