### PR TITLE
Confirm Python 3.12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     services:
       postgres:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Release
 
+#### Improvements
+- Python: Confirm Python 3.12 support ([#572](https://github.com/jazzband/django-auditlog/pull/572))
+
 ## 3.0.0-beta.2 (2023-10-05)
 
 #### Breaking Changes

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.1",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
     {py38,py39,py310}-django32
-    {py38,py39,py310,py311}-django{41,42}
-    {py310,py311}-djangomain
+    {py38,py39,py310,py311}-django41
+    {py38,py39,py310,py311,py312}-django42
+    {py310,py311,py312}-djangomain
     py38-docs
     py38-lint
 
@@ -30,6 +31,7 @@ passenv=
     TEST_DB_PORT
 
 basepython =
+    py312: python3.12
     py311: python3.11
     py310: python3.10
     py39: python3.9
@@ -51,3 +53,4 @@ python =
   3.9: py39
   3.10: py310
   3.11: py311
+  3.12: py312

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
     {py38,py39,py310}-django32
-    {py38,py39,py310,py311}-django41
-    {py38,py39,py310,py311,py312}-django42
+    {py38,py39,py310,py311}-django{41,42}
     {py310,py311,py312}-djangomain
     py38-docs
     py38-lint


### PR DESCRIPTION
I followed the pattern set by the previous 3.11 MR: #447 

The tox envlist change might be debatable, but my understanding is that Python 3.12 will only be supported on 4.2 and above.

As my colleague mentioned in #570, we've just started using v3 of this package, so happy to chip in with small things like this. I thought it might want adding for 3.0. We know that we shouldn't be using v3 yet, but the risk level is fine for what we're doing.

Thanks for your efforts!