### PR TITLE
Fix Read The Docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,3 +23,5 @@ formats: all
 python:
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
Fixes https://github.com/jazzband/help/issues/345.

`pip install .` during the build to fix:

```pytb
Running Sphinx v7.2.6

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-auditlog/envs/latest/lib/python3.11/site-packages/sphinx/config.py", line 358, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-auditlog/checkouts/latest/docs/source/conf.py", line 13, in <module>
    from auditlog import __version__
ModuleNotFoundError: No module named 'auditlog'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-auditlog/envs/latest/lib/python3.11/site-packages/sphinx/cmd/build.py", line 293, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-auditlog/envs/latest/lib/python3.11/site-packages/sphinx/application.py", line 211, in __init__
    self.config = Config.read(self.confdir, confoverrides or {}, self.tags)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-auditlog/envs/latest/lib/python3.11/site-packages/sphinx/config.py", line 181, in read
    namespace = eval_config_file(filename, tags)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-auditlog/envs/latest/lib/python3.11/site-packages/sphinx/config.py", line 371, in eval_config_file
    raise ConfigError(msg % traceback.format_exc()) from exc
sphinx.errors.ConfigError: There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-auditlog/envs/latest/lib/python3.11/site-packages/sphinx/config.py", line 358, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-auditlog/checkouts/latest/docs/source/conf.py", line 13, in <module>
    from auditlog import __version__
ModuleNotFoundError: No module named 'auditlog'


Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-auditlog/envs/latest/lib/python3.11/site-packages/sphinx/config.py", line 358, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-auditlog/checkouts/latest/docs/source/conf.py", line 13, in <module>
    from auditlog import __version__
ModuleNotFoundError: No module named 'auditlog'
```

https://readthedocs.org/projects/django-auditlog/builds/22324726/

It built successfully on my branch:

* https://readthedocs.org/projects/hugovk-django-auditlog/builds/22367497/
* https://hugovk-django-auditlog.readthedocs.io/en/fix-rtd/
