### PR TITLE
Conditionally disable / enable logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Release
 
-#### Breaking Changes
+#### Improvements
 - feat: If any receiver returns False, no logging will be made. This can be useful if logging should be conditionally enabled / disabled ([#590](https://github.com/jazzband/django-auditlog/pull/590))
 
 ## 3.0.0-beta.3 (2023-11-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Release
 
+#### Breaking Changes
+- feat: If any receiver returns False, no logging will be made. This can be useful if logging should be conditionally enabled / disabled ([#590](https://github.com/jazzband/django-auditlog/pull/590))
+
 ## 3.0.0-beta.3 (2023-11-13)
 
 #### Improvements

--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -108,10 +108,10 @@ def _create_log_entry(
         instance=instance,
         action=action,
     )
-    
+
     if any(item[1] is False for item in pre_log_results):
         return
-        
+
     error = None
     log_created = False
     changes = None

--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -108,6 +108,10 @@ def _create_log_entry(
         instance=instance,
         action=action,
     )
+    
+    if any(item[1] is False for item in pre_log_results):
+        return
+        
     error = None
     log_created = False
     changes = None

--- a/auditlog/signals.py
+++ b/auditlog/signals.py
@@ -20,8 +20,8 @@ Keyword arguments sent with this signal:
     audit log entry. Type: :class:`auditlog.models.LogEntry.Action`
 
 The receivers' return values are sent to any :func:`post_log`
-signal receivers, with one exception: if any receiver returns False, 
-no logging will be made. This can be useful if logging should be 
+signal receivers, with one exception: if any receiver returns False,
+no logging will be made. This can be useful if logging should be
 conditionally enabled / disabled
 """
 

--- a/auditlog/signals.py
+++ b/auditlog/signals.py
@@ -20,7 +20,9 @@ Keyword arguments sent with this signal:
     audit log entry. Type: :class:`auditlog.models.LogEntry.Action`
 
 The receivers' return values are sent to any :func:`post_log`
-signal receivers.
+signal receivers, with one exception: if any receiver returns False, 
+no logging will be made. This can be useful if logging should be 
+conditionally enabled / disabled
 """
 
 post_log = django.dispatch.Signal()

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -2420,6 +2420,34 @@ class SignalTests(TestCase):
 
         self.assertSignals(LogEntry.Action.CREATE)
 
+    def test_disabled_logging(self):
+        log_count = LogEntry.objects.count()
+
+        def pre_log_receiver(sender, instance, action, **_kwargs):
+            return True
+
+        def pre_log_receiver_extra(*_args, **_kwargs):
+            pass
+
+        def pre_log_receiver_disable(*_args, **_kwargs):
+            return False
+
+        pre_log.connect(pre_log_receiver)
+        pre_log.connect(pre_log_receiver_extra)
+
+        self.obj = SimpleModel.objects.create(text="I am not difficult.")
+
+        self.assertEqual(LogEntry.objects.count(), log_count + 1)
+
+        log_count = LogEntry.objects.count()
+
+        pre_log.connect(pre_log_receiver_disable)
+
+        self.obj = SimpleModel.objects.create(text="I am not difficult.")
+
+        self.assertEqual(LogEntry.objects.count(), log_count)
+
+
     def test_custom_signals_update(self):
         def pre_log_receiver(sender, instance, action, **_kwargs):
             self.my_pre_log_data["is_called"] = True

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -2447,7 +2447,6 @@ class SignalTests(TestCase):
 
         self.assertEqual(LogEntry.objects.count(), log_count)
 
-
     def test_custom_signals_update(self):
         def pre_log_receiver(sender, instance, action, **_kwargs):
             self.my_pre_log_data["is_called"] = True


### PR DESCRIPTION
If any receiver returns False, no logging will be made. This can be useful if logging should be conditionally enabled / disabled

Closes #589 possibly #586 