### PR TITLE
Add custom data and actor email

### DIFF
--- a/auditlog/admin.py
+++ b/auditlog/admin.py
@@ -29,9 +29,9 @@ class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
         f"actor__{get_user_model().USERNAME_FIELD}",
     ]
     list_filter = ["action", ResourceTypeFilter, CIDFilter]
-    readonly_fields = ["created", "resource_url", "action", "user_url", "msg"]
+    readonly_fields = ["created", "resource_url", "action", "user_url", "msg", "custom_data"]
     fieldsets = [
-        (None, {"fields": ["created", "user_url", "resource_url", "cid"]}),
+        (None, {"fields": ["created", "user_url", "resource_url", "custom_data", "cid"]}),
         (_("Changes"), {"fields": ["action", "msg"]}),
     ]
 

--- a/auditlog/context.py
+++ b/auditlog/context.py
@@ -23,7 +23,9 @@ def set_actor(actor, remote_addr=None):
     auditlog_value.set(context_data)
 
     # Connect signal for automatic logging
-    set_actor = partial(_set_actor, user=actor, signal_duid=context_data["signal_duid"])
+    set_actor = partial(
+        _set_actor, user=actor, signal_duid=context_data["signal_duid"],
+    )
     pre_save.connect(
         set_actor,
         sender=LogEntry,
@@ -61,6 +63,7 @@ def _set_actor(user, sender, instance, signal_duid, **kwargs):
             and instance.actor is None
         ):
             instance.actor = user
+            instance.actor_email = user.email
 
         instance.remote_addr = auditlog["remote_addr"]
 

--- a/auditlog/migrations/0016_add_actor_email.py
+++ b/auditlog/migrations/0016_add_actor_email.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("auditlog", "0015_alter_logentry_changes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="logentry",
+            name="actor_email",
+            field=models.CharField(
+                null=True, verbose_name="actor email", blank=True, max_length=254,
+            ),
+        ),
+    ]

--- a/auditlog/migrations/0017_add_custom_data.py
+++ b/auditlog/migrations/0017_add_custom_data.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("auditlog", "0016_add_actor_email"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="logentry",
+            name="custom_data",
+            field=models.JSONField(
+                null=True, verbose_name="custom data", blank=True,
+            ),
+        ),
+    ]

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -378,6 +378,7 @@ class LogEntry(models.Model):
         blank=True, null=True, verbose_name=_("additional data")
     )
     actor_email = models.CharField(blank=True, null=True, max_length=254)
+    custom_data = models.JSONField(blank=True, null=True)
 
     objects = LogEntryManager()
 

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -377,8 +377,10 @@ class LogEntry(models.Model):
     additional_data = models.JSONField(
         blank=True, null=True, verbose_name=_("additional data")
     )
+    actor_email = models.CharField(blank=True, null=True, max_length=254)
 
     objects = LogEntryManager()
+
 
     class Meta:
         get_latest_by = "timestamp"

--- a/auditlog_tests/test_two_step_json_migration.py
+++ b/auditlog_tests/test_two_step_json_migration.py
@@ -47,7 +47,17 @@ class AuditlogMigrateJsonTest(TestCase):
         call_command(
             "auditlogmigratejson", *args, stdout=outbuf, stderr=errbuf, **kwargs
         )
-        return outbuf.getvalue().strip(), errbuf.getvalue().strip()
+        outbuf = self._remove_formatters(outbuf)
+        errbuf = self._remove_formatters(errbuf)
+        return outbuf, errbuf
+
+    @staticmethod
+    def _remove_formatters(outbuf):
+        return (outbuf.getvalue().strip()
+                .replace('\x1b[0m', '')
+                .replace('\x1b[32;1m', '')
+                .replace('\x1b[33;1m', '')
+                .replace('\x1b[31;1m', ''))
 
     def test_nothing_to_migrate(self):
         outbuf, errbuf = self.call_command()


### PR DESCRIPTION
### add actor_email
deleting a user from the Users table will make actor_id useless (its only a bunch of characters). by adding email as static content, it can be usable forever.

### adding custom_data 
most of the time, data change is not the only thing you need. for example in a real environment with a bunch of CLI actions and Crons, you need some additional records to specify the task that causes the change. by using custom_data, its possible to attach any data to the history log.
example:

```python
with set_auditlog_custom_data(custom_data={"type": "management_command", "command": "clear_unused_records")}):
    target_function(obj)
```
