### PR TITLE
Include `LogEntry` instance in `post_log` signal

### DIFF
--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -113,7 +113,7 @@ def _create_log_entry(
         return
 
     error = None
-    log_created = False
+    log_entry = None
     changes = None
     try:
         changes = model_instance_diff(
@@ -121,17 +121,16 @@ def _create_log_entry(
         )
 
         if force_log or changes:
-            LogEntry.objects.log_create(
+            log_entry = LogEntry.objects.log_create(
                 instance,
                 action=action,
                 changes=changes,
                 force_log=force_log,
             )
-            log_created = True
     except BaseException as e:
         error = e
     finally:
-        if log_created or error:
+        if log_entry or error:
             post_log.send(
                 sender,
                 instance=instance,
@@ -140,7 +139,8 @@ def _create_log_entry(
                 error=error,
                 pre_log_results=pre_log_results,
                 changes=changes,
-                log_created=log_created,
+                log_entry=log_entry,
+                log_created=log_entry is not None,
             )
         if error:
             raise error

--- a/auditlog/signals.py
+++ b/auditlog/signals.py
@@ -48,6 +48,10 @@ Keyword arguments sent with this signal:
     this will be None. In some cases, such as when logging access to the instance,
     the changes will be an empty dict.
 
+:param Optional[LogEntry] log_entry:
+    The log entry that was created and stored in the database. If there was an error,
+    this will be None.
+
 :param bool log_created:
     Was the log actually created?
     This could be false if there was an error in creating the log.

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -2380,6 +2380,7 @@ class SignalTests(TestCase):
             "my_instance": None,
             "my_action": None,
             "my_error": None,
+            "my_log_entry": None,
         }
 
     def assertSignals(self, action):
@@ -2397,6 +2398,7 @@ class SignalTests(TestCase):
         self.assertIs(self.my_post_log_data["my_instance"], self.obj)
         self.assertEqual(self.my_post_log_data["my_action"], action)
         self.assertIsNone(self.my_post_log_data["my_error"])
+        self.assertIsNotNone(self.my_post_log_data["my_log_entry"])
 
     def test_custom_signals(self):
         my_ret_val = random.randint(0, 10000)
@@ -2413,13 +2415,14 @@ class SignalTests(TestCase):
             return my_other_ret_val
 
         def post_log_receiver(
-            sender, instance, action, error, pre_log_results, **_kwargs
+            sender, instance, action, error, log_entry, pre_log_results, **_kwargs
         ):
             self.my_post_log_data["is_called"] = True
             self.my_post_log_data["my_sender"] = sender
             self.my_post_log_data["my_instance"] = instance
             self.my_post_log_data["my_action"] = action
             self.my_post_log_data["my_error"] = error
+            self.my_post_log_data["my_log_entry"] = log_entry
 
             self.assertEqual(len(pre_log_results), 2)
 
@@ -2482,12 +2485,13 @@ class SignalTests(TestCase):
             self.my_pre_log_data["my_instance"] = instance
             self.my_pre_log_data["my_action"] = action
 
-        def post_log_receiver(sender, instance, action, error, **_kwargs):
+        def post_log_receiver(sender, instance, action, error, log_entry, **_kwargs):
             self.my_post_log_data["is_called"] = True
             self.my_post_log_data["my_sender"] = sender
             self.my_post_log_data["my_instance"] = instance
             self.my_post_log_data["my_action"] = action
             self.my_post_log_data["my_error"] = error
+            self.my_post_log_data["my_log_entry"] = log_entry
 
         pre_log.connect(pre_log_receiver)
         post_log.connect(post_log_receiver)
@@ -2504,12 +2508,13 @@ class SignalTests(TestCase):
             self.my_pre_log_data["my_instance"] = instance
             self.my_pre_log_data["my_action"] = action
 
-        def post_log_receiver(sender, instance, action, error, **_kwargs):
+        def post_log_receiver(sender, instance, action, error, log_entry, **_kwargs):
             self.my_post_log_data["is_called"] = True
             self.my_post_log_data["my_sender"] = sender
             self.my_post_log_data["my_instance"] = instance
             self.my_post_log_data["my_action"] = action
             self.my_post_log_data["my_error"] = error
+            self.my_post_log_data["my_log_entry"] = log_entry
 
         pre_log.connect(pre_log_receiver)
         post_log.connect(post_log_receiver)


### PR DESCRIPTION
Thank you for maintaining this great project! While working on a specific use case where I wanted to further process audit messages, I stumbled across the fact that the `post_log` signal which has been introduced in v3 somehow does not contain the actual instance of the `LogEntry` that has been created and saved.

This was rather confusing to me and makes it impossible to implement my use case, which also requires access to fields like `cid`, `remote_addr`, `timestamp` or `actor` - for the latter I even found an open issue #576 on this repository, where a user was also missing the possibility to access the actor of a `LogEntry`.

While all kinds of fields could be added to the signal, I hereby propose to simply pass the actual `LogEntry` instance as part of the signal when available, which I deem a simpler solution and avoids adding more and more arguments to the signal. This PR adds the `log_entry` argument, which is either an instance of `LogEntry` (= changes made/force-log and persisted) or `None` (= error occurred).

This will allow easily accessing all the available model fields in a signal or even directly interacting with the specific LogEntry instance in other ways. Merging this PR would fix #576 as well.