### PR TITLE
Avoid exception in `changes_display_dict` when model is missing

### DIFF
--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -436,11 +436,14 @@ class LogEntry(models.Model):
         """
         :return: The changes recorded in this log entry intended for display to users as a dictionary object.
         """
-        # Get the model and model_fields
         from auditlog.registry import auditlog
 
+        # Get the model and model_fields, but gracefully handle the case where the model no longer exists
         model = self.content_type.model_class()
-        model_fields = auditlog.get_model_fields(model._meta.model)
+        model_fields = None
+        if auditlog.contains(model._meta.model):
+            model_fields = auditlog.get_model_fields(model._meta.model)
+
         changes_display_dict = {}
         # grab the changes_dict and iterate through
         for field_name, values in self.changes_dict.items():
@@ -501,9 +504,13 @@ class LogEntry(models.Model):
                         value = f"{value[:140]}..."
 
                     values_display.append(value)
-            verbose_name = model_fields["mapping_fields"].get(
-                field.name, getattr(field, "verbose_name", field.name)
-            )
+
+            # Use verbose_name from mapping if available, otherwise determine from field
+            if model_fields and field.name in model_fields["mapping_fields"]:
+                verbose_name = model_fields["mapping_fields"][field.name]
+            else:
+                verbose_name = getattr(field, "verbose_name", field.name)
+
             changes_display_dict[verbose_name] = values_display
         return changes_display_dict
 

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -2613,3 +2613,19 @@ class DisableTest(TestCase):
         self.assertEqual(0, LogEntry.objects.get_for_object(recursive).count())
         related = ManyRelatedOtherModel.objects.get(pk=1)
         self.assertEqual(0, LogEntry.objects.get_for_object(related).count())
+
+
+class MissingModelTest(TestCase):
+    def setUp(self):
+        # Create a log entry, then unregister the model
+        self.obj = SimpleModel.objects.create(text="I am old.")
+        auditlog.unregister(SimpleModel)
+
+    def tearDown(self):
+        # Re-register the model for other tests
+        auditlog.register(SimpleModel)
+
+    def test_get_changes_for_missing_model(self):
+        history = self.obj.history.latest()
+        self.assertEqual(history.changes_dict["text"][1], self.obj.text)
+        self.assertEqual(history.changes_display_dict["text"][1], self.obj.text)


### PR DESCRIPTION
As django-auditlog v3 now stores the actual PKs for foreign models instead of their string representation, I switched my application from `changes_dict` to `changes_display_dict` so that the actual string-representation of foreign models is being shown again. While this worked in my local environment, it broke while trying out this change against a previously used testing database, specifically by raising a `KeyError`.

As it turns out, if a model has been previously registered with django-auditlog and made any entries, followed by then being no longer registered (e.g. if the model has been deprecated or further logging is no longer desired), any calls to `changes_display_dict` will fail. The reason behind this is that the method attempts to lookup the model within the registry, without checking if it actually still exists.

This lookup is only needed for respecting `mapping_fields` and has no other purpose. This PR extends the logic to first check if the model is contained in the registry, and only if that is the case, the actual lookup happens. If a previously existing model is being looked up instead, it will still show up properly, just without the mapped fields as they no longer exist.