### PR TITLE
Correcting a typo in usage.rst

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -233,7 +233,7 @@ It must be a list or tuple. Each item in this setting can be a:
     AUDITLOG_INCLUDE_TRACKING_MODELS = (
         "<appname>.<model1>",
         {
-            "model": "<appname>.<model1>",
+            "model": "<appname>.<model2>",
             "include_fields": ["field1", "field2"],
             "exclude_fields": ["field3", "field4"],
             "mapping_fields": {


### PR DESCRIPTION
The code example for AUDITLOG_INCLUDE_TRACKING_MODELS made two distinct references to "model1" which seems to be a typo, should read "model2" on the second reference