### PR TITLE
Disable logging remote IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 3.0.0-beta.4 (2024-01-02)
 
 #### Improvements
-- feat: Excluding ip address when AUDITLOG_DISABLE_REMOTE_ADDR is set to True ([#620](https://github.com/jazzband/django-auditlog/pull/620))
+- feat: Excluding ip address when `AUDITLOG_DISABLE_REMOTE_ADDR` is set to True ([#620](https://github.com/jazzband/django-auditlog/pull/620))
 - feat: If any receiver returns False, no logging will be made. This can be useful if logging should be conditionally enabled / disabled ([#590](https://github.com/jazzband/django-auditlog/pull/590))
 - Django: Confirm Django 5.0 support ([#598](https://github.com/jazzband/django-auditlog/pull/598))
 - Django: Drop Django 4.1 support ([#598](https://github.com/jazzband/django-auditlog/pull/598))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 3.0.0-beta.4 (2024-01-02)
 
 #### Improvements
+- feat: Excluding ip address when AUDITLOG_DISABLE_REMOTE_ADDR is set to True ([#620](https://github.com/jazzband/django-auditlog/pull/620))
 - feat: If any receiver returns False, no logging will be made. This can be useful if logging should be conditionally enabled / disabled ([#590](https://github.com/jazzband/django-auditlog/pull/590))
 - Django: Confirm Django 5.0 support ([#598](https://github.com/jazzband/django-auditlog/pull/598))
 - Django: Drop Django 4.1 support ([#598](https://github.com/jazzband/django-auditlog/pull/598))

--- a/auditlog/conf.py
+++ b/auditlog/conf.py
@@ -40,3 +40,8 @@ settings.AUDITLOG_TWO_STEP_MIGRATION = getattr(
 settings.AUDITLOG_USE_TEXT_CHANGES_IF_JSON_IS_NOT_PRESENT = getattr(
     settings, "AUDITLOG_USE_TEXT_CHANGES_IF_JSON_IS_NOT_PRESENT", False
 )
+
+# Disable remote_addr field in database
+settings.AUDITLOG_DISABLE_REMOTE_ADDR = getattr(
+    settings, "AUDITLOG_DISABLE_REMOTE_ADDR", False
+)

--- a/auditlog/middleware.py
+++ b/auditlog/middleware.py
@@ -13,11 +13,9 @@ class AuditlogMiddleware:
 
     def __init__(self, get_response=None):
         self.get_response = get_response
-        self.disable_remote_addr = getattr(
-            settings, "AUDITLOG_DISABLE_REMOTE_ADDR", False
-        )
-        if not isinstance(self.disable_remote_addr, bool):
+        if not isinstance(settings. AUDITLOG_DISABLE_REMOTE_ADDR, bool):
             raise TypeError("Setting 'AUDITLOG_DISABLE_REMOTE_ADDR' must be a boolean")
+        self.disable_remote_addr = settings. AUDITLOG_DISABLE_REMOTE_ADDR
 
     @staticmethod
     def _get_remote_addr(request):

--- a/auditlog/middleware.py
+++ b/auditlog/middleware.py
@@ -13,9 +13,9 @@ class AuditlogMiddleware:
 
     def __init__(self, get_response=None):
         self.get_response = get_response
-        if not isinstance(settings. AUDITLOG_DISABLE_REMOTE_ADDR, bool):
+        if not isinstance(settings.AUDITLOG_DISABLE_REMOTE_ADDR, bool):
             raise TypeError("Setting 'AUDITLOG_DISABLE_REMOTE_ADDR' must be a boolean")
-        self.disable_remote_addr = settings. AUDITLOG_DISABLE_REMOTE_ADDR
+        self.disable_remote_addr = settings.AUDITLOG_DISABLE_REMOTE_ADDR
 
     @staticmethod
     def _get_remote_addr(request):

--- a/auditlog/middleware.py
+++ b/auditlog/middleware.py
@@ -17,7 +17,7 @@ class AuditlogMiddleware:
             settings, "AUDITLOG_DISABLE_REMOTE_ADDR", False
         )
         if not isinstance(self.disable_remote_addr, bool):
-            raise ValueError("Setting 'AUDITLOG_DISABLE_REMOTE_ADDR' must be a boolean")
+            raise TypeError("Setting 'AUDITLOG_DISABLE_REMOTE_ADDR' must be a boolean")
 
     @staticmethod
     def _get_remote_addr(request):

--- a/auditlog/middleware.py
+++ b/auditlog/middleware.py
@@ -15,10 +15,12 @@ class AuditlogMiddleware:
         self.get_response = get_response
         if not isinstance(settings.AUDITLOG_DISABLE_REMOTE_ADDR, bool):
             raise TypeError("Setting 'AUDITLOG_DISABLE_REMOTE_ADDR' must be a boolean")
-        self.disable_remote_addr = settings.AUDITLOG_DISABLE_REMOTE_ADDR
 
     @staticmethod
     def _get_remote_addr(request):
+        if settings.AUDITLOG_DISABLE_REMOTE_ADDR:
+            return None
+
         # In case there is no proxy, return the original address
         if not request.headers.get("X-Forwarded-For"):
             return request.META.get("REMOTE_ADDR")
@@ -42,10 +44,7 @@ class AuditlogMiddleware:
         return None
 
     def __call__(self, request):
-        if self.disable_remote_addr:
-            remote_addr = None
-        else:
-            remote_addr = self._get_remote_addr(request)
+        remote_addr = self._get_remote_addr(request)
         user = self._get_actor(request)
 
         set_cid(request)

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -515,7 +515,9 @@ class MiddlewareTest(TestCase):
 
     def test_init_middleware(self):
         with override_settings(AUDITLOG_DISABLE_REMOTE_ADDR="str"):
-            with self.assertRaisesMessage(TypeError, "Setting 'AUDITLOG_DISABLE_REMOTE_ADDR' must be a boolean"):
+            with self.assertRaisesMessage(
+                TypeError, "Setting 'AUDITLOG_DISABLE_REMOTE_ADDR' must be a boolean"
+            ):
                 AuditlogMiddleware()
 
     def test_disable_remote_addr(self):

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -513,6 +513,18 @@ class MiddlewareTest(TestCase):
 
         self.assert_no_listeners()
 
+    def test_init_middleware(self):
+        with override_settings(AUDITLOG_DISABLE_REMOTE_ADDR="str"):
+            with self.assertRaisesMessage(TypeError, "Setting 'AUDITLOG_DISABLE_REMOTE_ADDR' must be a boolean"):
+                AuditlogMiddleware()
+
+    def test_disable_remote_addr(self):
+        with override_settings(AUDITLOG_DISABLE_REMOTE_ADDR=True):
+            headers = {"HTTP_X_FORWARDED_FOR": "127.0.0.2"}
+            request = self.factory.get("/", **headers)
+            remote_addr = self.middleware._get_remote_addr(request)
+            self.assertIsNone(remote_addr)
+
     def test_get_remote_addr(self):
         tests = [  # (headers, expected_remote_addr)
             ({}, "127.0.0.1"),
@@ -1270,12 +1282,6 @@ class RegisterModelSettingsTest(TestCase):
         with override_settings(AUDITLOG_DISABLE_ON_RAW_SAVE="bad value"):
             with self.assertRaisesMessage(
                 TypeError, "Setting 'AUDITLOG_DISABLE_ON_RAW_SAVE' must be a boolean"
-            ):
-                self.test_auditlog.register_from_settings()
-
-        with override_settings(AUDITLOG_DISABLE_REMOTE_ADDR="str"):
-            with self.assertRaisesMessage(
-                TypeError, "Setting 'AUDITLOG_DISABLE_REMOTE_ADDR' must be a boolean"
             ):
                 self.test_auditlog.register_from_settings()
 

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1273,6 +1273,12 @@ class RegisterModelSettingsTest(TestCase):
             ):
                 self.test_auditlog.register_from_settings()
 
+        with override_settings(AUDITLOG_DISABLE_REMOTE_ADDR="str"):
+            with self.assertRaisesMessage(
+                TypeError, "Setting 'AUDITLOG_DISABLE_REMOTE_ADDR' must be a boolean"
+            ):
+                self.test_auditlog.register_from_settings()
+
     @override_settings(
         AUDITLOG_INCLUDE_ALL_MODELS=True,
         AUDITLOG_EXCLUDE_TRACKING_MODELS=("auditlog_tests.SimpleExcludeModel",),

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -206,6 +206,19 @@ It will be considered when ``AUDITLOG_INCLUDE_ALL_MODELS`` is `True`.
 
 .. versionadded:: 3.0.0
 
+**AUDITLOG_EXCLUDE_TRACKING_FIELDS**
+
+When using "AuditlogMiddleware",
+the IP address is logged by default, you can use this setting
+to exclude the IP address from logging.
+It will be considered when ``AUDITLOG_DISABLE_REMOTE_ADDR`` is `True`.
+
+.. code-block:: python
+
+    AUDITLOG_DISABLE_REMOTE_ADDR = True
+
+.. versionadded:: 3.0.0
+
 **AUDITLOG_EXCLUDE_TRACKING_MODELS**
 
 You can use this setting to exclude models in registration process.


### PR DESCRIPTION
Hello,
I've created this Pull Request in response to the user's request regarding the possibility to disable logging of the remote IP address in django-auditlog's audit logs (#524). This feature is desirable in the context of personal data protection, especially in compliance with the General Data Protection Regulation (GDPR).

In this Pull Request, I've added a new configuration, AUDITLOG_DISABLE_REMOTE_ADDR, which allows disabling the logging of the remote IP address. When this configuration is enabled, the remote IP address will no longer be recorded in the audit logs.

I've had to deal with this problem myself and I think it's important to address it for reasons of data confidentiality, which is why I've done this.