### PR TITLE
Add new settings attr AUDITLOG_REGISTRY to allow custom auditlogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 3.0.0-beta.4 (2024-01-02)
 
 #### Improvements
+- feat: Add `AUDITLOG_REGISTRY` settings attribute to have multiple auditlogs with custom configurations ([#623](https://github.com/jazzband/django-auditlog/pull/623))
 - feat: Excluding ip address when `AUDITLOG_DISABLE_REMOTE_ADDR` is set to True ([#620](https://github.com/jazzband/django-auditlog/pull/620))
 - feat: If any receiver returns False, no logging will be made. This can be useful if logging should be conditionally enabled / disabled ([#590](https://github.com/jazzband/django-auditlog/pull/590))
 - Django: Confirm Django 5.0 support ([#598](https://github.com/jazzband/django-auditlog/pull/598))

--- a/auditlog/conf.py
+++ b/auditlog/conf.py
@@ -45,3 +45,8 @@ settings.AUDITLOG_USE_TEXT_CHANGES_IF_JSON_IS_NOT_PRESENT = getattr(
 settings.AUDITLOG_DISABLE_REMOTE_ADDR = getattr(
     settings, "AUDITLOG_DISABLE_REMOTE_ADDR", False
 )
+
+# List of paths to auditlogs
+settings.AUDITLOG_REGISTRY = getattr(
+    settings, "AUDITLOG_REGISTRY", ["auditlog.registry.auditlog"]
+)

--- a/auditlog/diff.py
+++ b/auditlog/diff.py
@@ -124,7 +124,7 @@ def model_instance_diff(
             field values as value.
     :rtype: dict
     """
-    from auditlog.registry import auditlog
+    from auditlog.registry import AuditlogRegistry
 
     if not (old is None or isinstance(old, Model)):
         raise TypeError("The supplied old instance is not a valid model instance.")
@@ -135,13 +135,13 @@ def model_instance_diff(
 
     if old is not None and new is not None:
         fields = set(old._meta.fields + new._meta.fields)
-        model_fields = auditlog.get_model_fields(new._meta.model)
+        model_fields = AuditlogRegistry.get_model_fields(new._meta.model)
     elif old is not None:
         fields = set(get_fields_in_model(old))
-        model_fields = auditlog.get_model_fields(old._meta.model)
+        model_fields = AuditlogRegistry.get_model_fields(old._meta.model)
     elif new is not None:
         fields = set(get_fields_in_model(new))
-        model_fields = auditlog.get_model_fields(new._meta.model)
+        model_fields = AuditlogRegistry.get_model_fields(new._meta.model)
     else:
         fields = set()
         model_fields = None

--- a/auditlog/mixins.py
+++ b/auditlog/mixins.py
@@ -11,7 +11,7 @@ from django.utils.timezone import is_aware, localtime
 from django.utils.translation import gettext_lazy as _
 
 from auditlog.models import LogEntry
-from auditlog.registry import auditlog
+from auditlog.registry import AuditlogRegistry
 from auditlog.signals import accessed
 
 MAX = 75
@@ -142,7 +142,7 @@ class LogEntryAdminMixin:
         if model is None:
             return field_name
         try:
-            model_fields = auditlog.get_model_fields(model._meta.model)
+            model_fields = AuditlogRegistry.get_model_fields(model._meta.model)
             mapping_field_name = model_fields["mapping_fields"].get(field_name)
             if mapping_field_name:
                 return mapping_field_name

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -222,7 +222,9 @@ class LogEntryManager(models.Manager):
         return pk
 
     def _get_serialized_data_or_none(self, instance):
-        from auditlog.registry import auditlog
+        from auditlog.registry import AuditlogRegistry
+
+        auditlog = AuditlogRegistry.get_auditlog(model=instance.__class__)
 
         opts = auditlog.get_serialize_options(instance.__class__)
         if not opts["serialize_data"]:
@@ -436,12 +438,14 @@ class LogEntry(models.Model):
         """
         :return: The changes recorded in this log entry intended for display to users as a dictionary object.
         """
-        from auditlog.registry import auditlog
+        from auditlog.registry import AuditlogRegistry
 
         # Get the model and model_fields, but gracefully handle the case where the model no longer exists
         model = self.content_type.model_class()
+        auditlog = AuditlogRegistry.get_auditlog(model=model)
+
         model_fields = None
-        if auditlog.contains(model._meta.model):
+        if auditlog:
             model_fields = auditlog.get_model_fields(model._meta.model)
 
         changes_display_dict = {}

--- a/auditlog_tests/admin.py
+++ b/auditlog_tests/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 
-from auditlog.registry import auditlog
+from auditlog.registry import get_default_auditlogs
 
-for model in auditlog.get_models():
-    admin.site.register(model)
+for auditlog in get_default_auditlogs():
+    for model in auditlog.get_models():
+        admin.site.register(model)

--- a/auditlog_tests/apps.py
+++ b/auditlog_tests/apps.py
@@ -3,3 +3,12 @@ from django.apps import AppConfig
 
 class AuditlogTestConfig(AppConfig):
     name = "auditlog_tests"
+
+    def ready(self) -> None:
+        from auditlog_tests.test_registry import (
+            create_only_auditlog,
+            update_only_auditlog,
+        )
+
+        create_only_auditlog.register_from_settings()
+        update_only_auditlog.register_from_settings()

--- a/auditlog_tests/test_registry.py
+++ b/auditlog_tests/test_registry.py
@@ -1,0 +1,16 @@
+from auditlog.registry import AuditlogModelRegistry
+
+create_only_auditlog = AuditlogModelRegistry(
+    create=True,
+    update=False,
+    delete=False,
+    access=False,
+    m2m=False,
+)
+update_only_auditlog = AuditlogModelRegistry(
+    create=False,
+    update=True,
+    delete=False,
+    access=False,
+    m2m=False,
+)

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -289,6 +289,17 @@ If the value is `None`, the default getter will be used.
 
 .. versionadded:: 3.0.0
 
+**AUDITLOG_REGISTRY**
+A list or tuple of AuditlogModelRegistry instances.
+This settings allow to configure multiple auditlogs with conditionally disabled logging per action
+or to have custom signal receivers.
+
+If not specified, this setting defaults to:
+.. code-block:: python
+    AUDITLOG_REGISTRY = ["auditlog.registry.auditlog"]
+
+.. versionadded:: 3.0.0
+
 Actors
 ------
 


### PR DESCRIPTION
This PR is to close #617

I've added a new configuration `AUDITLOG_REGISTRY`, paths to custom auditlog instances
which allow to configure models logging with flexible options (conditionally disabled/enabled logging and custom signal receivers)