### PR TITLE
add actor email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Improvements
 
+- feat: Added 'LogEntry.actor_email` field. ([#641](https://github.com/jazzband/django-auditlog/pull/641))
 - Add Python 3.13 support. ([#671](https://github.com/jazzband/django-auditlog/pull/671))
 - feat: Added `LogEntry.remote_port` field. ([#671](https://github.com/jazzband/django-auditlog/pull/671))
 - feat: Added `truncate` option to `auditlogflush` management command. ([#681](https://github.com/jazzband/django-auditlog/pull/681))

--- a/auditlog/context.py
+++ b/auditlog/context.py
@@ -24,7 +24,11 @@ def set_actor(actor, remote_addr=None, remote_port=None):
     auditlog_value.set(context_data)
 
     # Connect signal for automatic logging
-    set_actor = partial(_set_actor, user=actor, signal_duid=context_data["signal_duid"])
+    set_actor = partial(
+        _set_actor,
+        user=actor,
+        signal_duid=context_data["signal_duid"],
+    )
     pre_save.connect(
         set_actor,
         sender=LogEntry,
@@ -62,6 +66,7 @@ def _set_actor(user, sender, instance, signal_duid, **kwargs):
             and instance.actor is None
         ):
             instance.actor = user
+            instance.actor_email = hasattr(user, "email") and user.email or None
 
         instance.remote_addr = auditlog["remote_addr"]
         instance.remote_port = auditlog["remote_port"]

--- a/auditlog/migrations/0017_add_actor_email.py
+++ b/auditlog/migrations/0017_add_actor_email.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("auditlog", "0016_logentry_remote_port"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="logentry",
+            name="actor_email",
+            field=models.CharField(
+                null=True,
+                verbose_name="actor email",
+                blank=True,
+                max_length=254,
+            ),
+        ),
+    ]

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -384,6 +384,7 @@ class LogEntry(models.Model):
     additional_data = models.JSONField(
         blank=True, null=True, verbose_name=_("additional data")
     )
+    actor_email = models.CharField(blank=True, null=True, max_length=254)
 
     objects = LogEntryManager()
 

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -262,7 +262,10 @@ class WithActorMixin:
         super().setUp()
 
     def tearDown(self):
+        user_email = self.user.email
         self.user.delete()
+        auditlog_entries = LogEntry.objects.filter(actor_email=user_email).all()
+        self.assertIsNotNone(auditlog_entries, msg="All auditlog entries are deleted.")
         super().tearDown()
 
     def make_object(self):
@@ -272,6 +275,7 @@ class WithActorMixin:
     def check_create_log_entry(self, obj, log_entry):
         super().check_create_log_entry(obj, log_entry)
         self.assertEqual(log_entry.actor, self.user)
+        self.assertEqual(log_entry.actor_email, self.user.email)
 
     def update(self, obj):
         with set_actor(self.user):
@@ -280,6 +284,7 @@ class WithActorMixin:
     def check_update_log_entry(self, obj, log_entry):
         super().check_update_log_entry(obj, log_entry)
         self.assertEqual(log_entry.actor, self.user)
+        self.assertEqual(log_entry.actor_email, self.user.email)
 
     def delete(self, obj):
         with set_actor(self.user):
@@ -288,6 +293,7 @@ class WithActorMixin:
     def check_delete_log_entry(self, obj, log_entry):
         super().check_delete_log_entry(obj, log_entry)
         self.assertEqual(log_entry.actor, self.user)
+        self.assertEqual(log_entry.actor_email, self.user.email)
 
 
 class AltPrimaryKeyModelBase(SimpleModelTest):


### PR DESCRIPTION
# add actor_email
deleting a user from the Users table will make actor_id useless (its only a bunch of characters). by adding email as static content, it can be usable forever.