### PR TITLE
Disable admin interface from settings.py

### DIFF
--- a/auditlog/admin.py
+++ b/auditlog/admin.py
@@ -1,5 +1,6 @@
 from functools import cached_property
 
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
@@ -9,7 +10,6 @@ from auditlog.mixins import LogEntryAdminMixin
 from auditlog.models import LogEntry
 
 
-@admin.register(LogEntry)
 class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
     list_select_related = ["content_type", "actor"]
     list_display = [
@@ -57,3 +57,7 @@ class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
     def get_queryset(self, request):
         self.request = request
         return super().get_queryset(request=request)
+
+
+if not settings.AUDITLOG_DISABLE_ADMIN_INTERFACE:
+    admin.site.register(LogEntry, LogEntryAdmin)

--- a/auditlog/conf.py
+++ b/auditlog/conf.py
@@ -26,6 +26,11 @@ settings.AUDITLOG_DISABLE_ON_RAW_SAVE = getattr(
     settings, "AUDITLOG_DISABLE_ON_RAW_SAVE", False
 )
 
+# Disable django admin interface
+settings.AUDITLOG_DISABLE_ADMIN_INTERFACE = getattr(
+    settings, "AUDITLOG_DISABLE_ADMIN_INTERFACE", False
+)
+
 # CID
 
 settings.AUDITLOG_CID_HEADER = getattr(

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -463,3 +463,10 @@ Django Admin integration
 
 When ``auditlog`` is added to your ``INSTALLED_APPS`` setting a customized admin class is active providing an enhanced
 Django Admin interface for log entries.
+
+
+If you want to not register the django admin interface, you can set the following setting:
+
+.. code-block:: python
+
+    AUDITLOG_DISABLE_ADMIN_INTERFACE = True


### PR DESCRIPTION
Disables admin interface by adding `AUDITLOG_DISABLE_ADMIN_INTERFACE = False` in settings.py