### PR TITLE
Use `attname` to get pk value

### DIFF
--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -213,12 +213,11 @@ class LogEntryManager(models.Manager):
         :type instance: Model
         :return: The primary key value of the given model instance.
         """
-        pk_field = instance._meta.pk.name
+        pk_field = instance._meta.pk.attname
         pk = getattr(instance, pk_field, None)
 
         # Check to make sure that we got a pk not a model object.
-        if isinstance(pk, models.Model):
-            pk = self._get_pk_value(pk)
+        assert not isinstance(pk, models.Model)
         return pk
 
     def _get_serialized_data_or_none(self, instance):

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -213,10 +213,12 @@ class LogEntryManager(models.Manager):
         :type instance: Model
         :return: The primary key value of the given model instance.
         """
+        # Should be equivalent to `instance.pk`.
         pk_field = instance._meta.pk.attname
         pk = getattr(instance, pk_field, None)
 
         # Check to make sure that we got a pk not a model object.
+        # Should be guaranteed as we used `attname` above, not `name`.
         assert not isinstance(pk, models.Model)
         return pk
 

--- a/auditlog_tests/models.py
+++ b/auditlog_tests/models.py
@@ -63,7 +63,10 @@ class ModelPrimaryKeyModel(models.Model):
     """
 
     key = models.OneToOneField(
-        "SimpleModel", primary_key=True, on_delete=models.CASCADE, related_name="reverse_primary_key"
+        "SimpleModel",
+        primary_key=True,
+        on_delete=models.CASCADE,
+        related_name="reverse_primary_key",
     )
 
     text = models.TextField(blank=True)

--- a/auditlog_tests/models.py
+++ b/auditlog_tests/models.py
@@ -57,6 +57,23 @@ class UUIDPrimaryKeyModel(models.Model):
     history = AuditlogHistoryField(delete_related=True, pk_indexable=False)
 
 
+class ModelPrimaryKeyModel(models.Model):
+    """
+    A model with another model as primary key.
+    """
+
+    key = models.OneToOneField(
+        "SimpleModel", primary_key=True, on_delete=models.CASCADE, related_name="reverse_primary_key"
+    )
+
+    text = models.TextField(blank=True)
+    boolean = models.BooleanField(default=False)
+    integer = models.IntegerField(blank=True, null=True)
+    datetime = models.DateTimeField(auto_now=True)
+
+    history = AuditlogHistoryField(delete_related=True, pk_indexable=False)
+
+
 class ProxyModel(SimpleModel):
     """
     A model that is a proxy for another model.
@@ -338,6 +355,7 @@ class AutoManyRelatedModel(models.Model):
 
 auditlog.register(AltPrimaryKeyModel)
 auditlog.register(UUIDPrimaryKeyModel)
+auditlog.register(ModelPrimaryKeyModel)
 auditlog.register(ProxyModel)
 auditlog.register(RelatedModel)
 auditlog.register(ManyRelatedModel)

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -336,9 +336,7 @@ class UUIDPrimaryKeyModelModelWithActorTest(
 class ModelPrimaryKeyModelBase(SimpleModelTest):
     def make_object(self):
         self.key = super().make_object()
-        return ModelPrimaryKeyModel.objects.create(
-            key=self.key, text="I am strange."
-        )
+        return ModelPrimaryKeyModel.objects.create(key=self.key, text="I am strange.")
 
 
 class ModelPrimaryKeyModelTest(NoActorMixin, ModelPrimaryKeyModelBase):
@@ -356,9 +354,7 @@ class ModelPrimaryKeyTest(TransactionTestCase):
         Test that the primary key can be retrieved without additional database queries.
         """
         key = SimpleModel.objects.create(text="I am not difficult.")
-        obj = ModelPrimaryKeyModel.objects.create(
-            key=key, text="I am strange."
-        )
+        obj = ModelPrimaryKeyModel.objects.create(key=key, text="I am strange.")
         # Refresh the object so the primary key object is not cached.
         obj.refresh_from_db()
         with self.assertNumQueries(0):


### PR DESCRIPTION
If a model's primary key is another model, the current implementation of `LogEntryManager._get_pk_value` will needlessly pull in the entire object only to extract its primary key and discard it. This change gets the primary key directly from the first object.

The `attname` field isn't particularly well documented in Django, but it is briefly mentioned [here](https://docs.djangoproject.com/en/5.0/ref/models/fields/#django.db.models.Field.pre_save).

On the base `Field` class, it is the same as `name`:

https://github.com/django/django/blob/adae619426b6f50046b3daaa744db52989c9d6db/django/db/models/fields/__init__.py#L973-L974

Whereas for `ForeignKey`, it is `{name}_id`:

https://github.com/django/django/blob/adae619426b6f50046b3daaa744db52989c9d6db/django/db/models/fields/related.py#L1117-L1118

Happy to remove the `assert` if you'd prefer not to use it.