### PR TITLE
Reorder condition in get_field_value function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fixed a problem when setting `Value(None)` in `JSONField` ([#646](https://github.com/jazzband/django-auditlog/pull/646))
 - Fixed a problem when setting `django.db.models.functions.Now()` in `DateTimeField` ([#635](https://github.com/jazzband/django-auditlog/pull/635))
-- Changed the order of `rel_class` and `one_to_one` and `many_to_one` in `get_field_value` function. ([#XXX](https://github.com/jazzband/django-auditlog/pull/652))
+- Changed the order of `rel_class` and `one_to_one` and `many_to_one` in `get_field_value` function. ([#652](https://github.com/jazzband/django-auditlog/pull/652))
 
 ## 3.0.0 (2024-04-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed a problem when setting `Value(None)` in `JSONField` ([#646](https://github.com/jazzband/django-auditlog/pull/646))
 - Fixed a problem when setting `django.db.models.functions.Now()` in `DateTimeField` ([#635](https://github.com/jazzband/django-auditlog/pull/635))
+- Changed the order of `rel_class` and `one_to_one` and `many_to_one` in `get_field_value` function. ([#XXX](https://github.com/jazzband/django-auditlog/pull/652))
 
 ## 3.0.0 (2024-04-12)
 

--- a/auditlog/diff.py
+++ b/auditlog/diff.py
@@ -83,7 +83,7 @@ def get_field_value(obj, field):
                 value = json.dumps(value, sort_keys=True, cls=field.encoder)
             except TypeError:
                 pass
-        elif (field.one_to_one or field.many_to_one) and hasattr(field, "rel_class"):
+        elif hasattr(field, "rel_class") and (field.one_to_one or field.many_to_one):
             value = smart_str(
                 getattr(obj, field.get_attname(), None), strings_only=True
             )

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -30,7 +30,7 @@ from django.utils.translation import gettext_lazy as _
 from auditlog.admin import LogEntryAdmin
 from auditlog.cid import get_cid
 from auditlog.context import disable_auditlog, set_actor
-from auditlog.diff import model_instance_diff
+from auditlog.diff import model_instance_diff, get_field_value
 from auditlog.middleware import AuditlogMiddleware
 from auditlog.models import DEFAULT_OBJECT_REPR, LogEntry
 from auditlog.registry import AuditlogModelRegistry, AuditLogRegistrationError, auditlog
@@ -2163,6 +2163,19 @@ class TestRelatedDiffs(TestCase):
         log_update = instance.history.filter(timestamp=t2).first()
         self.assertEqual(int(log_create.changes_dict["related"][1]), one_simple.id)
         self.assertEqual(int(log_update.changes_dict["related"][1]), two_simple.id)
+
+    def test_rel_class_checked_first(self):
+        mock_field = mock.Mock()
+
+        type(mock_field).rel_class = mock.PropertyMock(return_value=None)
+        type(mock_field).one_to_one = mock.PropertyMock(return_value=True)
+        type(mock_field).many_to_one = mock.PropertyMock(return_value=True)
+
+        mock_obj = mock.Mock()
+
+        get_field_value(mock_obj, mock_field)
+
+        assert "rel_class" == mock_field.method_calls[0]
 
 
 class TestModelSerialization(TestCase):

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -2175,7 +2175,7 @@ class TestRelatedDiffs(TestCase):
 
         get_field_value(mock_obj, mock_field)
 
-        assert "rel_class" == mock_field.method_calls[0]
+        self.assertEqual("rel_class", mock_field.method_calls[0])
 
 
 class TestModelSerialization(TestCase):

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -30,7 +30,7 @@ from django.utils.translation import gettext_lazy as _
 from auditlog.admin import LogEntryAdmin
 from auditlog.cid import get_cid
 from auditlog.context import disable_auditlog, set_actor
-from auditlog.diff import model_instance_diff, get_field_value
+from auditlog.diff import get_field_value, model_instance_diff
 from auditlog.middleware import AuditlogMiddleware
 from auditlog.models import DEFAULT_OBJECT_REPR, LogEntry
 from auditlog.registry import AuditlogModelRegistry, AuditLogRegistrationError, auditlog


### PR DESCRIPTION
Hello there,

Some projects have their own fields that are not connected to any model. With the previous approach, the code would have broken, but with this order, it will consider those too. What do you think?