### PR TITLE
Sync django query and postgres query

### DIFF
--- a/auditlog/management/commands/auditlogmigratejson.py
+++ b/auditlog/management/commands/auditlogmigratejson.py
@@ -125,7 +125,13 @@ class Command(BaseCommand):
         def postgres():
             with connection.cursor() as cursor:
                 cursor.execute(
-                    'UPDATE auditlog_logentry SET changes="changes_text"::jsonb'
+                    """
+                    UPDATE auditlog_logentry
+                    SET changes="changes_text"::jsonb
+                    WHERE changes_text IS NOT NULL
+                        AND changes_text <> ''
+                        AND changes IS NULL
+                    """
                 )
                 return cursor.cursor.rowcount
 

--- a/auditlog_tests/test_two_step_json_migration.py
+++ b/auditlog_tests/test_two_step_json_migration.py
@@ -135,6 +135,21 @@ class AuditlogMigrateJsonTest(TestCase):
         self.assertEqual(errbuf, "")
         self.assertIsNotNone(log_entry.changes)
 
+    def test_native_postgres_changes_not_overwritten(self):
+        # Arrange
+        log_entry = self.make_logentry()
+        log_entry.changes = original_changes = {"key": "value"}
+        log_entry.changes_text = '{"key": "new value"}'
+        log_entry.save()
+
+        # Act
+        outbuf, errbuf = self.call_command("-d=postgres")
+        log_entry.refresh_from_db()
+
+        # Assert
+        self.assertEqual(errbuf, "")
+        self.assertEqual(log_entry.changes, original_changes)
+
     def test_native_unsupported(self):
         # Arrange
         log_entry = self.make_logentry()


### PR DESCRIPTION
The [upgrade documentation](https://django-auditlog.readthedocs.io/en/latest/upgrade.html) recommends a multi-stage upgrade, during which some records might have a `changes` field that is no longer empty. This case is handled in the Django query but not in the Postgres one.

Additionally, if there are many records and the upgrade fails, we are returned to the initial state, which is not ideal.

This change should take care of these problems :crossed_fingers: 