### PR TITLE
Added --no-color args in test migration

### DIFF
--- a/auditlog_tests/test_two_step_json_migration.py
+++ b/auditlog_tests/test_two_step_json_migration.py
@@ -44,6 +44,7 @@ class AuditlogMigrateJsonTest(TestCase):
     def call_command(self, *args, **kwargs):
         outbuf = StringIO()
         errbuf = StringIO()
+        args = ("--no-color",) + args
         call_command(
             "auditlogmigratejson", *args, stdout=outbuf, stderr=errbuf, **kwargs
         )


### PR DESCRIPTION
In some cases the tests break when the migration messages are output with colors in the terminal