### PR TITLE
feat: Add truncate option to flush command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Improvements
 
 - feat: Added `LogEntry.remote_port` field. ([#671](https://github.com/jazzband/django-auditlog/pull/671))
+- feat: Added `truncate` option to `auditlogflush` management command. ([#681](https://github.com/jazzband/django-auditlog/pull/681))
 - Drop Python 3.8 support. ([#678](https://github.com/jazzband/django-auditlog/pull/678))
 - Confirm Django 5.1 support and drop Django 3.2 support. ([#677](https://github.com/jazzband/django-auditlog/pull/677))
 

--- a/auditlog_tests/test_commands.py
+++ b/auditlog_tests/test_commands.py
@@ -166,3 +166,26 @@ class AuditlogFlushWithTruncateTest(TransactionTestCase):
             msg="Output shows warning and table gets truncate",
         )
         self.assertEqual(err, "", msg="No stderr")
+
+    @mock.patch(
+        "django.db.connection.vendor",
+        new_callable=mock.PropertyMock(return_value="unknown"),
+    )
+    @mock.patch(
+        "django.db.connection.display_name",
+        new_callable=mock.PropertyMock(return_value="Unknown"),
+    )
+    def test_flush_with_truncate_for_unsupported_database_vendor(
+        self, mocked_vendor, mocked_db_name
+    ):
+        obj = self.make_object()
+        self.assertEqual(obj.history.count(), 1, msg="There is one log entry.")
+        out, err = self.call_command("--truncate", "--y")
+
+        self.assertEqual(obj.history.count(), 1, msg="There is still one log entry.")
+        self.assertEqual(
+            out,
+            "Database Unknown does not support truncate statement.",
+            msg="Output shows error",
+        )
+        self.assertEqual(err, "", msg="No stderr")


### PR DESCRIPTION
Fixes #680 
Passing `--truncate` to flush command executes a truncate SQL statement, instead of deleting log records. 