### PR TITLE
Use recommended manager to query related models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ via `AUDITLOG_MASK_TRACKING_FIELDS` setting. ([#702](https://github.com/jazzband
 - fix: Use sender instead of receiver for `m2m_changed` signal ID to prevent duplicate entries for models that share a related model. ([#686](https://github.com/jazzband/django-auditlog/pull/686))
 - Fixed a problem when setting `Value(None)` in `JSONField` ([#646](https://github.com/jazzband/django-auditlog/pull/646))
 - Fixed a problem when setting `django.db.models.functions.Now()` in `DateTimeField` ([#635](https://github.com/jazzband/django-auditlog/pull/635))
+- Use the [default manager](https://docs.djangoproject.com/en/5.1/topics/db/managers/#default-managers) instead of `objects` to support custom model managers. ([#705](https://github.com/jazzband/django-auditlog/pull/705))
 
 ## 3.0.0 (2024-04-12)
 

--- a/auditlog/models.py
+++ b/auditlog/models.py
@@ -542,7 +542,7 @@ class LogEntry(models.Model):
             return value
         # Attempt to return the string representation of the object
         try:
-            return smart_str(field.related_model.objects.get(pk=pk_value))
+            return smart_str(field.related_model._default_manager.get(pk=pk_value))
         # ObjectDoesNotExist will be raised if the object was deleted.
         except ObjectDoesNotExist:
             return f"Deleted '{field.related_model.__name__}' ({value})"

--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -55,7 +55,7 @@ def log_update(sender, instance, **kwargs):
     """
     if not instance._state.adding:
         update_fields = kwargs.get("update_fields", None)
-        old = sender.objects.filter(pk=instance.pk).first()
+        old = sender._default_manager.filter(pk=instance.pk).first()
         _create_log_entry(
             action=LogEntry.Action.UPDATE,
             instance=instance,
@@ -156,9 +156,11 @@ def make_log_m2m_changes(field_name):
             return
 
         if action == "post_clear":
-            changed_queryset = kwargs["model"].objects.all()
+            changed_queryset = kwargs["model"]._default_manager.all()
         else:
-            changed_queryset = kwargs["model"].objects.filter(pk__in=kwargs["pk_set"])
+            changed_queryset = kwargs["model"]._default_manager.filter(
+                pk__in=kwargs["pk_set"]
+            )
 
         if action in ["post_add"]:
             LogEntry.objects.log_m2m_changes(

--- a/auditlog_tests/models.py
+++ b/auditlog_tests/models.py
@@ -407,6 +407,19 @@ class SimpleNonManagedModel(models.Model):
         managed = False
 
 
+class SecretManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().filter(is_secret=False)
+
+
+@auditlog.register()
+class SwappedManagerModel(models.Model):
+    is_secret = models.BooleanField(default=False)
+    name = models.CharField(max_length=255)
+
+    objects = SecretManager()
+
+
 class AutoManyRelatedModel(models.Model):
     related = models.ManyToManyField(SimpleModel)
 


### PR DESCRIPTION
When using custom managers, I stumbled over unexpected behavior of the `log_update` signal. The signal directly uses the `objects` manager. From https://docs.djangoproject.com/en/5.1/topics/db/managers/#default-managers:

> If you’re writing some code that must handle an unknown model, for example, in a third-party app that implements a generic view, use this manager (or [_base_manager](https://docs.djangoproject.com/en/5.1/topics/db/managers/#django.db.models.Model._base_manager)) rather than assuming the model has an objects manager.

This is the result of some simple grepping, so it might not be complete.