### PR TITLE
Fix IntegrityError when cloning objects with pk=None (#664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ via `AUDITLOG_MASK_TRACKING_FIELDS` setting. ([#702](https://github.com/jazzband
 - Fixed a problem when setting `Value(None)` in `JSONField` ([#646](https://github.com/jazzband/django-auditlog/pull/646))
 - Fixed a problem when setting `django.db.models.functions.Now()` in `DateTimeField` ([#635](https://github.com/jazzband/django-auditlog/pull/635))
 - Use the [default manager](https://docs.djangoproject.com/en/5.1/topics/db/managers/#default-managers) instead of `objects` to support custom model managers. ([#705](https://github.com/jazzband/django-auditlog/pull/705))
+- Fixed crashes when cloning objects with `pk=None` ([#707](https://github.com/jazzband/django-auditlog/pull/707))
 
 ## 3.0.0 (2024-04-12)
 

--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -53,7 +53,7 @@ def log_update(sender, instance, **kwargs):
 
     Direct use is discouraged, connect your model through :py:func:`auditlog.registry.register` instead.
     """
-    if not instance._state.adding:
+    if not instance._state.adding and instance.pk is not None:
         update_fields = kwargs.get("update_fields", None)
         old = sender._default_manager.filter(pk=instance.pk).first()
         _create_log_entry(

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -235,6 +235,12 @@ class SimpleModelTest(TestCase):
         history = self.obj.history.filter(timestamp=timestamp, changes="foo bar")
         self.assertTrue(history.exists())
 
+    def test_create_duplicate_with_pk_none(self):
+        initial_entries_count = LogEntry.objects.count()
+        obj = self.obj
+        obj.pk = None
+        obj.save()
+        self.assertEqual(LogEntry.objects.count(), initial_entries_count + 1)
 
 class NoActorMixin:
     def check_create_log_entry(self, obj, log_entry):
@@ -346,6 +352,9 @@ class ModelPrimaryKeyModelBase(SimpleModelTest):
     def make_object(self):
         self.key = super().make_object()
         return ModelPrimaryKeyModel.objects.create(key=self.key, text="I am strange.")
+
+    def test_create_duplicate_with_pk_none(self):
+        pass
 
 
 class ModelPrimaryKeyModelTest(NoActorMixin, ModelPrimaryKeyModelBase):

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -242,6 +242,7 @@ class SimpleModelTest(TestCase):
         obj.save()
         self.assertEqual(LogEntry.objects.count(), initial_entries_count + 1)
 
+
 class NoActorMixin:
     def check_create_log_entry(self, obj, log_entry):
         super().check_create_log_entry(obj, log_entry)


### PR DESCRIPTION
Hi, thank you for `auditlog`.

This pull request fixes bug number #664. It is naive implementation but it seems that it works as expected. Please let me know what you think so I can adjust the patch accordingly.