### PR TITLE
CI: Add required pkginfo to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools twine wheel
+          python -m pip install -U setuptools twine wheel pkginfo
 
       - name: Build package
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@
 
 #### Fixes
 
-- CI: Add required pkginfo to release workflow
-
-
 ## 3.1.0 (2025-04-15)
 
 #### Improvements
@@ -25,6 +22,7 @@ via `AUDITLOG_MASK_TRACKING_FIELDS` setting. ([#702](https://github.com/jazzband
 
 #### Fixes
 
+- CI: Add required pkginfo to release workflow
 - fix: Use sender instead of receiver for `m2m_changed` signal ID to prevent duplicate entries for models that share a related model. ([#686](https://github.com/jazzband/django-auditlog/pull/686))
 - Fixed a problem when setting `Value(None)` in `JSONField` ([#646](https://github.com/jazzband/django-auditlog/pull/646))
 - Fixed a problem when setting `django.db.models.functions.Now()` in `DateTimeField` ([#635](https://github.com/jazzband/django-auditlog/pull/635))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 #### Fixes
 
+- CI: Add required pkginfo to release workflow
+
+
 ## 3.1.0 (2025-04-15)
 
 #### Improvements


### PR DESCRIPTION
The build package distribution generate the following error when pushed to PyPI

```
Uploading distributions to https://upload.pypi.org/legacy/ �[31mERROR �[0m InvalidDistribution:
Metadata is missing required fields: Name, Version. Make sure the distribution includes the files 
where those fields are specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2, 2.0, 
2.1, 2.2, 2.3.
```

According to https://github.com/pypi/warehouse/issues/15611 this can be fixed by updating `pkginfo`. I therefore added pkginfo to release install dependency step.

I did build wheel locally and checked METADATA and it seems to be ok now

```
﻿Metadata-Version: 2.4
Name: django-auditlog
Version: 3.0.0.post37+g33831da
...
```

Hopefully closes #713 🤞 

@hramezani:

- Can I validate myself if the generated files are valid?
- Should I prep a new release after this is merged or should we roll this PR into the 3.1.0 release (also move Changelog entry accordingly)?