### PR TITLE
Pin libraries to fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools twine wheel pkginfo
+          python -m pip install -U setuptools==75.6.0 twine==6.0.1 wheel pkginfo
 
       - name: Build package
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@
 
 #### Fixes
 
-## 3.1.01 (2025-04-16)
+## 3.1.2 (2025-04-26)
+
+#### Fixes
+
+- CI: Pine twine and setuptools to fix release
+
+## 3.1.1 (2025-04-16)
 
 #### Fixes
 


### PR DESCRIPTION
Pins setuptools to 75.6.0 and twine to 6.0.1 which hopefully fixes release problem according to comment here https://github.com/pypi/warehouse/issues/15611#issuecomment-2793628089

Not a huge fan of pinning dependencies but not sure if we have a different option right now. These pins should be removed down the line when it hopefully again works with latest version of setuptools and twine

Should fix https://github.com/jazzband/django-auditlog/issues/713

