### PR TITLE
new setting: STORE_JSON_CHANGES that intelligently store JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Improvements
 
+- feat: Support storing JSON in the changes field when ```AUDITLOG_STORE_JSON_CHANGES``` is enabled.  ([#719](https://github.com/jazzband/django-auditlog/pull/719))
+
 #### Fixes
 
 ## 3.1.2 (2025-04-26)

--- a/auditlog/conf.py
+++ b/auditlog/conf.py
@@ -55,3 +55,8 @@ settings.AUDITLOG_DISABLE_REMOTE_ADDR = getattr(
 settings.AUDITLOG_CHANGE_DISPLAY_TRUNCATE_LENGTH = getattr(
     settings, "AUDITLOG_CHANGE_DISPLAY_TRUNCATE_LENGTH", 140
 )
+
+# Use pure JSON for changes field
+settings.AUDITLOG_STORE_JSON_CHANGES = getattr(
+    settings, "AUDITLOG_STORE_JSON_CHANGES", False
+)

--- a/auditlog/diff.py
+++ b/auditlog/diff.py
@@ -95,8 +95,7 @@ def get_field_value(obj, field, use_json_for_changes=False):
                 value = smart_str(value)
                 if type(value).__name__ == "__proxy__":
                     value = str(value)
-            
-            
+
     except ObjectDoesNotExist:
         value = (
             field.default
@@ -106,25 +105,16 @@ def get_field_value(obj, field, use_json_for_changes=False):
 
     return value
 
+
 def is_primitive(obj) -> bool:
     """
     Checks if the given object is a primitive Python type that can be safely serialized to JSON.
-    
+
     :param obj: The object to check
     :return: True if the object is a primitive type, False otherwise
     :rtype: bool
     """
-    primitive_types = (
-        type(None),
-        bool,
-        int,
-        float,
-        str,
-        list,
-        tuple,
-        dict,
-        set
-    )
+    primitive_types = (type(None), bool, int, float, str, list, tuple, dict, set)
     return isinstance(obj, primitive_types)
 
 
@@ -142,7 +132,10 @@ def mask_str(value: str) -> str:
 
 
 def model_instance_diff(
-    old: Optional[Model], new: Optional[Model], fields_to_check=None, use_json_for_changes=False
+    old: Optional[Model],
+    new: Optional[Model],
+    fields_to_check=None,
+    use_json_for_changes=False,
 ):
     """
     Calculates the differences between two model instances. One of the instances may be ``None``

--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -102,7 +102,14 @@ def log_access(sender, instance, **kwargs):
 
 
 def _create_log_entry(
-    action, instance, sender, diff_old, diff_new, fields_to_check=None, force_log=False, use_json_for_changes=False
+    action,
+    instance,
+    sender,
+    diff_old,
+    diff_new,
+    fields_to_check=None,
+    force_log=False,
+    use_json_for_changes=False,
 ):
     pre_log_results = pre_log.send(
         sender,
@@ -118,7 +125,10 @@ def _create_log_entry(
     changes = None
     try:
         changes = model_instance_diff(
-            diff_old, diff_new, fields_to_check=fields_to_check, use_json_for_changes=use_json_for_changes
+            diff_old,
+            diff_new,
+            fields_to_check=fields_to_check,
+            use_json_for_changes=use_json_for_changes,
         )
 
         if force_log or changes:

--- a/auditlog/receivers.py
+++ b/auditlog/receivers.py
@@ -43,6 +43,7 @@ def log_create(sender, instance, created, **kwargs):
             sender=sender,
             diff_old=None,
             diff_new=instance,
+            use_json_for_changes=settings.AUDITLOG_STORE_JSON_CHANGES,
         )
 
 
@@ -101,7 +102,7 @@ def log_access(sender, instance, **kwargs):
 
 
 def _create_log_entry(
-    action, instance, sender, diff_old, diff_new, fields_to_check=None, force_log=False
+    action, instance, sender, diff_old, diff_new, fields_to_check=None, force_log=False, use_json_for_changes=False
 ):
     pre_log_results = pre_log.send(
         sender,
@@ -117,7 +118,7 @@ def _create_log_entry(
     changes = None
     try:
         changes = model_instance_diff(
-            diff_old, diff_new, fields_to_check=fields_to_check
+            diff_old, diff_new, fields_to_check=fields_to_check, use_json_for_changes=use_json_for_changes
         )
 
         if force_log or changes:

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -370,7 +370,7 @@ class AuditlogModelRegistry:
                 self.register(
                     model=model, m2m_fields=m2m_fields, exclude_fields=exclude_fields
                 )
-        
+
         if not isinstance(settings.AUDITLOG_STORE_JSON_CHANGES, bool):
             raise TypeError("Setting 'AUDITLOG_STORE_JSON_CHANGES' must be a boolean")
 

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -370,6 +370,9 @@ class AuditlogModelRegistry:
                 self.register(
                     model=model, m2m_fields=m2m_fields, exclude_fields=exclude_fields
                 )
+        
+        if not isinstance(settings.AUDITLOG_STORE_JSON_CHANGES, bool):
+            raise TypeError("Setting 'AUDITLOG_STORE_JSON_CHANGES' must be a boolean")
 
         self._register_models(settings.AUDITLOG_INCLUDE_TRACKING_MODELS)
 

--- a/auditlog_tests/test_settings.py
+++ b/auditlog_tests/test_settings.py
@@ -34,8 +34,8 @@ DATABASES = {
             "TEST_DB_NAME", "auditlog" + os.environ.get("TOX_PARALLEL_ENV", "")
         ),
         "USER": os.getenv("TEST_DB_USER", "postgres"),
-        "PASSWORD": os.getenv("TEST_DB_PASS", "password"),
-        "HOST": os.getenv("TEST_DB_HOST", "localhost"),
+        "PASSWORD": os.getenv("TEST_DB_PASS", ""),
+        "HOST": os.getenv("TEST_DB_HOST", "127.0.0.1"),
         "PORT": os.getenv("TEST_DB_PORT", "5432"),
     }
 }

--- a/auditlog_tests/test_settings.py
+++ b/auditlog_tests/test_settings.py
@@ -34,8 +34,8 @@ DATABASES = {
             "TEST_DB_NAME", "auditlog" + os.environ.get("TOX_PARALLEL_ENV", "")
         ),
         "USER": os.getenv("TEST_DB_USER", "postgres"),
-        "PASSWORD": os.getenv("TEST_DB_PASS", ""),
-        "HOST": os.getenv("TEST_DB_HOST", "127.0.0.1"),
+        "PASSWORD": os.getenv("TEST_DB_PASS", "password"),
+        "HOST": os.getenv("TEST_DB_HOST", "localhost"),
         "PORT": os.getenv("TEST_DB_PORT", "5432"),
     }
 }

--- a/auditlog_tests/test_use_json_for_changes.py
+++ b/auditlog_tests/test_use_json_for_changes.py
@@ -8,8 +8,8 @@ class JSONForChangesTest(TestCase):
 
     def setUp(self):
         self.test_auditlog = AuditlogModelRegistry()
-    
-    @override_settings(AUDITLOG_STORE_JSON_CHANGES='str')
+
+    @override_settings(AUDITLOG_STORE_JSON_CHANGES="str")
     def test_wrong_setting_type(self):
         with self.assertRaisesMessage(
             TypeError, "Setting 'AUDITLOG_STORE_JSON_CHANGES' must be a boolean"

--- a/auditlog_tests/test_use_json_for_changes.py
+++ b/auditlog_tests/test_use_json_for_changes.py
@@ -58,7 +58,7 @@ class JSONForChangesTest(TestCase):
 
         id_field_changes = changes_dict["json"]
         self.assertEqual(id_field_changes, [None, []])
-    
+
     @override_settings(AUDITLOG_STORE_JSON_CHANGES=True)
     def test_use_json_for_changes_with_jsonmodel_with_complex_data(self):
         self.test_auditlog.register_from_settings()
@@ -67,17 +67,27 @@ class JSONForChangesTest(TestCase):
         json_model.json = {
             "key": "test_value",
             "key_dict": {"inner_key": "inner_value"},
-            "key_tuple": ("item1", "item2", "item3")
+            "key_tuple": ("item1", "item2", "item3"),
         }
         json_model.save()
         changes_dict = json_model.history.latest().changes_dict
 
         id_field_changes = changes_dict["json"]
-        self.assertEqual(id_field_changes, [None, {
-            "key": "test_value",
-            "key_dict": {"inner_key": "inner_value"},
-            "key_tuple": ["item1", "item2", "item3"] # tuple is converted to list, that's ok
-        }])
+        self.assertEqual(
+            id_field_changes,
+            [
+                None,
+                {
+                    "key": "test_value",
+                    "key_dict": {"inner_key": "inner_value"},
+                    "key_tuple": [
+                        "item1",
+                        "item2",
+                        "item3",
+                    ],  # tuple is converted to list, that's ok
+                },
+            ],
+        )
 
     @override_settings(AUDITLOG_STORE_JSON_CHANGES=True)
     def test_use_json_for_changes_with_jsonmodel_with_related_model(self):

--- a/auditlog_tests/test_use_json_for_changes.py
+++ b/auditlog_tests/test_use_json_for_changes.py
@@ -1,6 +1,7 @@
 from django.test import TestCase, override_settings
-from auditlog.registry import AuditlogModelRegistry
 from test_app.models import JSONModel, SimpleModel
+
+from auditlog.registry import AuditlogModelRegistry
 
 
 class JSONForChangesTest(TestCase):
@@ -21,7 +22,9 @@ class JSONForChangesTest(TestCase):
         # compare the id, text, boolean and datetime fields
         id_field_changes = changes_dict["id"]
         self.assertIsNone(id_field_changes[0])
-        self.assertIsInstance(id_field_changes[1], int)  # the id depends on state of the database
+        self.assertIsInstance(
+            id_field_changes[1], int
+        )  # the id depends on state of the database
 
         text_field_changes = changes_dict["text"]
         self.assertEqual(text_field_changes, [None, ""])
@@ -33,7 +36,6 @@ class JSONForChangesTest(TestCase):
         datetime_field_changes = changes_dict["datetime"]
         self.assertIsNone(datetime_field_changes[0])
         self.assertIsInstance(datetime_field_changes[1], str)
-
 
     @override_settings(AUDITLOG_STORE_JSON_CHANGES=True)
     def test_use_json_for_changes_with_jsonmodel(

--- a/auditlog_tests/test_use_json_for_changes.py
+++ b/auditlog_tests/test_use_json_for_changes.py
@@ -1,0 +1,50 @@
+from django.test import TestCase, override_settings
+from auditlog.registry import AuditlogModelRegistry
+from test_app.models import JSONModel, SimpleModel
+
+
+class JSONForChangesTest(TestCase):
+
+    def setUp(self):
+        self.test_auditlog = AuditlogModelRegistry()
+
+    @override_settings(AUDITLOG_STORE_JSON_CHANGES=True)
+    def test_use_json_for_changes_with_simplemodel(
+        self,
+    ):
+        self.test_auditlog.register_from_settings()
+
+        smm = SimpleModel()
+        smm.save()
+        changes_dict = smm.history.latest().changes_dict
+
+        # compare the id, text, boolean and datetime fields
+        id_field_changes = changes_dict["id"]
+        self.assertIsNone(id_field_changes[0])
+        self.assertIsInstance(id_field_changes[1], int)  # the id depends on state of the database
+
+        text_field_changes = changes_dict["text"]
+        self.assertEqual(text_field_changes, [None, ""])
+
+        boolean_field_changes = changes_dict["boolean"]
+        self.assertEqual(boolean_field_changes, [None, False])
+
+        # datetime should be serialized to string
+        datetime_field_changes = changes_dict["datetime"]
+        self.assertIsNone(datetime_field_changes[0])
+        self.assertIsInstance(datetime_field_changes[1], str)
+
+
+    @override_settings(AUDITLOG_STORE_JSON_CHANGES=True)
+    def test_use_json_for_changes_with_jsonmodel(
+        self,
+    ):
+        self.test_auditlog.register_from_settings()
+
+        json_model = JSONModel()
+        json_model.json = {"test_key": "test_value"}
+        json_model.save()
+        changes_dict = json_model.history.latest().changes_dict
+
+        id_field_changes = changes_dict["json"]
+        self.assertEqual(id_field_changes, [None, {"test_key": "test_value"}])

--- a/auditlog_tests/test_use_json_for_changes.py
+++ b/auditlog_tests/test_use_json_for_changes.py
@@ -8,6 +8,13 @@ class JSONForChangesTest(TestCase):
 
     def setUp(self):
         self.test_auditlog = AuditlogModelRegistry()
+    
+    @override_settings(AUDITLOG_STORE_JSON_CHANGES='str')
+    def test_wrong_setting_type(self):
+        with self.assertRaisesMessage(
+            TypeError, "Setting 'AUDITLOG_STORE_JSON_CHANGES' must be a boolean"
+        ):
+            self.test_auditlog.register_from_settings()
 
     @override_settings(AUDITLOG_STORE_JSON_CHANGES=True)
     def test_use_json_for_changes_with_simplemodel(self):

--- a/auditlog_tests/test_use_json_for_changes.py
+++ b/auditlog_tests/test_use_json_for_changes.py
@@ -10,9 +10,7 @@ class JSONForChangesTest(TestCase):
         self.test_auditlog = AuditlogModelRegistry()
 
     @override_settings(AUDITLOG_STORE_JSON_CHANGES=True)
-    def test_use_json_for_changes_with_simplemodel(
-        self,
-    ):
+    def test_use_json_for_changes_with_simplemodel(self):
         self.test_auditlog.register_from_settings()
 
         smm = SimpleModel()
@@ -38,9 +36,7 @@ class JSONForChangesTest(TestCase):
         self.assertIsInstance(datetime_field_changes[1], str)
 
     @override_settings(AUDITLOG_STORE_JSON_CHANGES=True)
-    def test_use_json_for_changes_with_jsonmodel(
-        self,
-    ):
+    def test_use_json_for_changes_with_jsonmodel(self):
         self.test_auditlog.register_from_settings()
 
         json_model = JSONModel()

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -337,6 +337,15 @@ Negative values: No truncation occurs, and the full string is displayed.
 
 .. versionadded:: 3.1.0
 
+**AUDITLOG_STORE_JSON_CHANGES**
+
+This configuration variable defines whether to store changes as JSON.
+
+This means that primitives such as booleans, integers, etc. will be represented using their JSON equivalents.  For example, instead of storing
+`None` as a string, it will be stored as a JSON `null` in the `changes` field.  Same goes for other primitives.
+
+.. versionadded:: 3.2.0
+
 Actors
 ------
 


### PR DESCRIPTION
## Descripton

This is a PR that implements issue #675, basically, storing the correct JSON type that corresponds to the Python type (`None` -> null, `1 -> 1', not `"1"`).

It's driven by a setting, `AUDITLOG_ STORE_JSON_CHANGES `, as recommended by @hramezani


From #675:
> The values in the changes object stored in the database ju
> st get turned into strings, such that all type information is lost.
> Here is what the changes column looks like in the database:
> 
```{"is_cool": ["False", "True"], "age": ["None", "42"]}```
> Instead, I would expect the following:
> 
```
> >>> log_entry.changes
> {'is_cool': [False, True], 'age': [None, 42]}
> >>> type(log_entry.changes['age'][0])
> <class 'NoneType'>
> >>> type(log_entry.changes['age'][1])
> <class 'int'>
```
> and the following JSON in the DB:
> 

```
> {"is_cool": [false, true], "age": [null, 42]}
```

## Tests

All existing tests pass, added a few new ones.  Probably needs more

## Feedback welcome
@aqeelat  @aleh-rymasheuski  ?