### PR TITLE
Use canonical timezone name for Buenos Aires

### DIFF
--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1737,7 +1737,7 @@ class AdminPanelTest(TestCase):
         for tz, timestamp in [
             ("UTC", "2022-08-01 12:00:00"),
             ("Asia/Tbilisi", "2022-08-01 16:00:00"),
-            ("America/Buenos_Aires", "2022-08-01 09:00:00"),
+            ("America/Argentina/Buenos_Aires", "2022-08-01 09:00:00"),
             ("Asia/Kathmandu", "2022-08-01 17:45:00"),
         ]:
             with self.settings(TIME_ZONE=tz):


### PR DESCRIPTION
Debian has moved legacy timezone names such as America/Buenos_Aires into
the tzdata-legacy package, which is not installed by default. The
canonical name for this timezone is America/Argentina/Buenos_Aires,
which remains in the standard tzdata package.

Update the test to use the canonical name to ensure compatibility with
default Debian installations.
