### PR TITLE
Update mysql version in test docker-compose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:8.4
         env:
           MYSQL_DATABASE: auditlog
           MYSQL_USER: mysql

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     -   id: pyupgrade
         args: [--py310-plus]
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.29.0
+    rev: 1.29.1
     hooks:
     - id: django-upgrade
       args: [--target-version, "4.2"]

--- a/auditlog_tests/docker-compose.yml
+++ b/auditlog_tests/docker-compose.yml
@@ -20,7 +20,7 @@ services:
   mysql:
     container_name: auditlog_mysql
     platform: linux/x86_64
-    image: mysql:8.0
+    image: mysql:8.4
     restart: "no"
     environment:
       MYSQL_DATABASE: auditlog


### PR DESCRIPTION
Django main requires mysql > 8.4

```
django.db.utils.NotSupportedError: MySQL 8.4 or later is required (found 8.0.44).
```
https://github.com/jazzband/django-auditlog/actions/runs/18850068183/job/53784166318?pr=776