### PR TITLE
Fix AttributeError when AUDITLOG_LOGENTRY_MODEL is not set (#788)

### DIFF
--- a/auditlog/__init__.py
+++ b/auditlog/__init__.py
@@ -10,10 +10,9 @@ __version__ = version("django-auditlog")
 
 
 def get_logentry_model():
+    model_string = getattr(settings, "AUDITLOG_LOGENTRY_MODEL", "auditlog.LogEntry")
     try:
-        return django_apps.get_model(
-            settings.AUDITLOG_LOGENTRY_MODEL, require_ready=False
-        )
+        return django_apps.get_model(model_string, require_ready=False)
     except ValueError:
         raise ImproperlyConfigured(
             "AUDITLOG_LOGENTRY_MODEL must be of the form 'app_label.model_name'"
@@ -21,5 +20,5 @@ def get_logentry_model():
     except LookupError:
         raise ImproperlyConfigured(
             "AUDITLOG_LOGENTRY_MODEL refers to model '%s' that has not been installed"
-            % settings.AUDITLOG_LOGENTRY_MODEL
+            % model_string
         )

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -3248,3 +3248,22 @@ class GetLogEntryModelTest(TestCase):
     def test_invalid_appname(self):
         with self.assertRaises(ImproperlyConfigured):
             get_logentry_model()
+
+    def test_logentry_model_default_when_setting_missing(self):
+        """Regression test for issue #788: AttributeError when AUDITLOG_LOGENTRY_MODEL is not set."""
+        # Save and remove the setting to simulate the bug condition
+        original_value = getattr(settings, "AUDITLOG_LOGENTRY_MODEL", None)
+        if hasattr(settings, "AUDITLOG_LOGENTRY_MODEL"):
+            delattr(settings, "AUDITLOG_LOGENTRY_MODEL")
+
+        try:
+            # This should NOT raise AttributeError - it should use the default
+            model = get_logentry_model()
+            self.assertEqual(
+                f"{model._meta.app_label}.{model._meta.object_name}",
+                "auditlog.LogEntry",
+            )
+        finally:
+            # Restore the original setting
+            if original_value is not None:
+                settings.AUDITLOG_LOGENTRY_MODEL = original_value


### PR DESCRIPTION
I hope I'm not stepping on toes with this, but I was following the issue thread and thought I'd give it a go. This is Claude Opus 4.5 assisted. I have verified that this fix works with my Django project. The Claude summary is below.

### Summary
- Fixed `AttributeError: 'Settings' object has no attribute 'AUDITLOG_LOGENTRY_MODEL'` that occurs when upgrading to 3.4.0+ without explicitly setting `AUDITLOG_LOGENTRY_MODEL`
- Added regression test to prevent this issue from recurring

### Problem
When Django's admin autodiscover imports `auditlog/admin.py` → `mixins.py`, the `get_logentry_model()` function is called at module load time before `conf.py` has a chance to apply the default value.

### Solution
Use `getattr()` with the default value directly in `get_logentry_model()`:
```python
model_string = getattr(settings, "AUDITLOG_LOGENTRY_MODEL", "auditlog.LogEntry")
```

This ensures the default is available regardless of import order, while still respecting user-defined custom values.

### Changes
- `auditlog/__init__.py`: Add `getattr()` fallback in `get_logentry_model()`
- `auditlog_tests/tests.py`: Add regression test `test_logentry_model_default_when_setting_missing`

Fixes #788
