### PR TITLE
Make AUDITLOG_LOGENTRY_MODEL swappable

### DIFF
--- a/auditlog/migrations/0001_initial.py
+++ b/auditlog/migrations/0001_initial.py
@@ -71,6 +71,7 @@ class Migration(migrations.Migration):
                 "get_latest_by": "timestamp",
                 "verbose_name": "log entry",
                 "verbose_name_plural": "log entries",
+                "swappable": "AUDITLOG_LOGENTRY_MODEL",
             },
             bases=(models.Model,),
         ),


### PR DESCRIPTION
Fixes #804

See issue description:

Prevents a dangling `auditlog_logentry` from conflicting with the flush management command. 