### PR TITLE
Add Python 3.14 and Django 6.0 to support matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
 
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     services:
       postgres:
         image: postgres:15
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     services:
       mysql:
         image: mysql:8.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Release
 
+#### Improvements
+
+- Add support for Python 3.14 and Django 6.0
+
 #### Fixes
 
 - `KeyError` when calling `changes_str` on a log entry that tracks many-to-many field changes ([#798](https://github.com/jazzband/django-auditlog/pull/798))

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,9 +12,9 @@ The repository can be found at https://github.com/jazzband/django-auditlog/.
 **Requirements**
 
 - Python 3.10 or higher
-- Django 4.2, 5.0, 5.1, and 5.2
+- Django 4.2, 5.0, 5.1, 5.2, and 6.0
 
-Auditlog is currently tested with Python 3.10+ and Django 4.2, 5.0, 5.1, and 5.2. The latest test report can be found
+Auditlog is currently tested with Python 3.10+ and Django 4.2, 5.0, 5.1, 5.2, and 6.0. The latest test report can be found
 at https://github.com/jazzband/django-auditlog/actions.
 
 Adding Auditlog to your Django application

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,13 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Framework :: Django",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
+        "Framework :: Django :: 6.0",
         "License :: OSI Approved :: MIT License",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@ envlist =
     {py310,py311}-django42
     {py310,py311,py312}-django50
     {py310,py311,py312,py313}-django51
-    {py310,py311,py312,py313}-django52
-    {py312,py313}-djangomain
+    {py310,py311,py312,py313,py314}-django52
+    {py312,py313,py314}-django60
+    {py313,py314}-djangomain
     py310-docs
     py310-lint
     py310-checkmigrations
@@ -24,6 +25,7 @@ deps =
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
     # Test requirements
     coverage
@@ -41,6 +43,7 @@ passenv=
     TEST_DB_PORT
 
 basepython =
+    py314: python3.14
     py313: python3.13
     py312: python3.12
     py311: python3.11
@@ -79,3 +82,4 @@ python =
   3.11: py311
   3.12: py312
   3.13: py313
+  3.14: py314


### PR DESCRIPTION
Bumps the test matrix and package classifiers to the latest releases,
Python 3.14 and Django 6.0. Lower bounds unchanged (Python 3.10, Django 4.2). 

Per Django's compatibility table: 5.2 covers Python 3.10–3.14, 6.0 covers 3.12–3.14.
(see https://docs.djangoproject.com/en/6.0/faq/install/)




