### PR TITLE
Switch the release workflow to PyPI Trusted Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,50 +4,98 @@ on:
   push:
     tags:
     - '*'
+    - '!*.dev*'
+
+env:
+  PYPI_URL: https://pypi.org/p/django-auditlog
 
 jobs:
   build:
-    if: github.repository == 'jazzband/django-auditlog'
+    name: Build distribution 📦
+    if: github.repository == 'django-commons/django-auditlog'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7
         with:
+          # setuptools_scm derives the version from git tags and history
           fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.x'
 
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: Install pypa/build
+        run: python -m pip install build --user
 
-      - name: Cache
-        uses: actions/cache@v6
+      - name: Build a binary wheel and a source tarball
+        run: python -m build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v6
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: release-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            release-
+          name: python-package-distributions
+          path: dist/
 
-      - name: Install dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U setuptools==75.6.0 twine==6.0.1 wheel pkginfo
+  publish-to-pypi:
+    name: Publish 📦 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: ${{ env.PYPI_URL }}
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
 
-      - name: Build package
-        run: |
-          python setup.py --version
-          python setup.py sdist --format=gztar bdist_wheel
-          twine check dist/*
-
-      - name: Upload packages to Jazzband
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v7
         with:
-          user: jazzband
-          password: ${{ secrets.JAZZBAND_RELEASE_KEY }}
-          repository-url: https://jazzband.co/projects/django-auditlog/upload
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.13
+
+  github-release:
+    name: Sign 📦 with Sigstore and create a GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.2.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          "${GITHUB_REF_NAME}"
+          --repo '${{ github.repository }}'
+          --notes ""
+
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload
+          "${GITHUB_REF_NAME}" dist/**
+          --repo '${{ github.repository }}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 target-version = ["py39"]
 


### PR DESCRIPTION
Before merging (repo settings, not in this diff):
- repo transferred to `django-commons` 
- PyPI Trusted Publisher configured: django-commons/django-auditlog, workflow release.yml, environment pypi
- pypi GitHub environment created

refs #811