### PR TITLE
Fix flaky test for deleted FK display dict

### DIFF
--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -2386,7 +2386,7 @@ class TestRelatedDiffs(TestCase):
         with freezegun.freeze_time(t2):
             one_simple.delete()
 
-        log_two = LogEntry.objects.filter(object_id=instance.id, timestamp=t2).first()
+        log_two = instance.history.filter(timestamp=t2).first()
         self.assertTrue(isinstance(log_two, LogEntry))
         display_dict = log_two.changes_display_dict
         self.assertEqual(


### PR DESCRIPTION
A delete cascade wrote two log rows the query could not tell apart, so `.first()` returned the wrong one at random and the test failed. Fetch through the model's own `history` instead. 


(see failing run: https://github.com/jazzband/django-auditlog/actions/runs/28929932966)