### PR TITLE
Fix ResourceTypeFilter 500 for invalid resource_type values Fixes #676

### DIFF
--- a/auditlog/filters.py
+++ b/auditlog/filters.py
@@ -1,4 +1,5 @@
 from django.contrib.admin import SimpleListFilter
+from django.contrib.admin.options import IncorrectLookupParameters
 from django.utils.translation import gettext_lazy as _
 
 
@@ -12,9 +13,14 @@ class ResourceTypeFilter(SimpleListFilter):
         return list(types.order_by("content_type__model").distinct())
 
     def queryset(self, request, queryset):
-        if self.value() is None:
+        value = self.value()
+        if value is None:
             return queryset
-        return queryset.filter(content_type_id=self.value())
+        try:
+            value = int(value)
+        except (TypeError, ValueError) as exc:
+            raise IncorrectLookupParameters(exc) from exc
+        return queryset.filter(content_type_id=value)
 
 
 class CIDFilter(SimpleListFilter):

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1858,6 +1858,12 @@ class AdminPanelTest(TestCase):
         self.assertTrue(self.admin.has_delete_permission(delete_object_request, log))
         self.assertFalse(self.admin.has_delete_permission(delete_log_request, log))
 
+    def _list_filter_params(self, request):
+        # Django 5.0+ ChangeList passes multi-value query params as lists.
+        if DJANGO_VERSION >= (5, 0):
+            return dict(request.GET.lists())
+        return request.GET.copy()
+
     def test_resource_type_filter_invalid_value_raises_incorrect_lookup_parameters(
         self,
     ):
@@ -1867,7 +1873,7 @@ class AdminPanelTest(TestCase):
         )
         request.user = self.user
         resource_type_filter = ResourceTypeFilter(
-            request, dict(request.GET.lists()), LogEntry, self.admin
+            request, self._list_filter_params(request), LogEntry, self.admin
         )
 
         with self.assertRaises(IncorrectLookupParameters):
@@ -1882,7 +1888,7 @@ class AdminPanelTest(TestCase):
         )
         request.user = self.user
         resource_type_filter = ResourceTypeFilter(
-            request, dict(request.GET.lists()), LogEntry, self.admin
+            request, self._list_filter_params(request), LogEntry, self.admin
         )
 
         result = resource_type_filter.queryset(request, LogEntry.objects.all())

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -12,6 +12,7 @@ from dateutil.tz import gettz
 from django import VERSION as DJANGO_VERSION
 from django.apps import apps
 from django.conf import settings
+from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, User
@@ -68,6 +69,7 @@ from test_app.models import (
 from auditlog import get_logentry_model
 from auditlog.admin import LogEntryAdmin
 from auditlog.cid import get_cid
+from auditlog.filters import ResourceTypeFilter
 from auditlog.context import disable_auditlog, set_actor, set_extra_data
 from auditlog.diff import mask_str, model_instance_diff
 from auditlog.middleware import AuditlogMiddleware
@@ -1855,6 +1857,21 @@ class AdminPanelTest(TestCase):
 
         self.assertTrue(self.admin.has_delete_permission(delete_object_request, log))
         self.assertFalse(self.admin.has_delete_permission(delete_log_request, log))
+
+    def test_resource_type_filter_invalid_value_raises_incorrect_lookup_parameters(
+        self,
+    ):
+        request = RequestFactory().get(
+            f"/{self.admin_path_prefix}/",
+            {"resource_type": "21X"},
+        )
+        request.user = self.user
+        resource_type_filter = ResourceTypeFilter(
+            request, dict(request.GET.lists()), LogEntry, self.admin
+        )
+
+        with self.assertRaises(IncorrectLookupParameters):
+            resource_type_filter.queryset(request, LogEntry.objects.all())
 
 
 class DiffMsgTest(TestCase):

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1859,10 +1859,11 @@ class AdminPanelTest(TestCase):
         self.assertFalse(self.admin.has_delete_permission(delete_log_request, log))
 
     def _list_filter_params(self, request):
-        # Django 5.0+ ChangeList passes multi-value query params as lists.
+        # Match ChangeList: Django 5.0+ uses lists(), 4.2 uses items() strings.
+        # QueryDict.pop() returns a list; Django 4.2 SimpleListFilter stores that as-is.
         if DJANGO_VERSION >= (5, 0):
             return dict(request.GET.lists())
-        return request.GET.copy()
+        return dict(request.GET.items())
 
     def test_resource_type_filter_invalid_value_raises_incorrect_lookup_parameters(
         self,

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -1873,6 +1873,23 @@ class AdminPanelTest(TestCase):
         with self.assertRaises(IncorrectLookupParameters):
             resource_type_filter.queryset(request, LogEntry.objects.all())
 
+    def test_resource_type_filter_valid_value_filters_queryset(self):
+        SimpleExcludeModel.objects.create(label="other", text="other")
+        content_type_id = self.obj.history.latest().content_type_id
+        request = RequestFactory().get(
+            f"/{self.admin_path_prefix}/",
+            {"resource_type": str(content_type_id)},
+        )
+        request.user = self.user
+        resource_type_filter = ResourceTypeFilter(
+            request, dict(request.GET.lists()), LogEntry, self.admin
+        )
+
+        result = resource_type_filter.queryset(request, LogEntry.objects.all())
+
+        self.assertEqual(result.count(), 1)
+        self.assertEqual(result.get().content_type_id, content_type_id)
+
 
 class DiffMsgTest(TestCase):
     def setUp(self):

--- a/auditlog_tests/tests.py
+++ b/auditlog_tests/tests.py
@@ -69,9 +69,9 @@ from test_app.models import (
 from auditlog import get_logentry_model
 from auditlog.admin import LogEntryAdmin
 from auditlog.cid import get_cid
-from auditlog.filters import ResourceTypeFilter
 from auditlog.context import disable_auditlog, set_actor, set_extra_data
 from auditlog.diff import mask_str, model_instance_diff
+from auditlog.filters import ResourceTypeFilter
 from auditlog.middleware import AuditlogMiddleware
 from auditlog.models import DEFAULT_OBJECT_REPR
 from auditlog.registry import AuditlogModelRegistry, AuditLogRegistrationError, auditlog


### PR DESCRIPTION
Fixes #676

Non-integer `resource_type` query values (e.g. `?resource_type=21X`) caused a `ValueError` and HTTP 500 on the LogEntry admin changelist.

`ResourceTypeFilter` now converts the value with `int()` and raises `IncorrectLookupParameters` on failure, matching Django admin's `FieldListFilter`.